### PR TITLE
feat: psychologist KPI SCORES — GAME CHANGER!

### DIFF
--- a/docs/ADMIN-API-EXAMPLES.md
+++ b/docs/ADMIN-API-EXAMPLES.md
@@ -2502,41 +2502,152 @@ Response:
 
 ### `GET /therapy-request-analytics/lifecycle`
 
-Admin/editor. Returns psychologist-level rankings and request-level rows for validation.
+Admin/editor. Returns KPI-based psychologist rankings and request-level audit rows. The route name is kept for compatibility.
+The KPI session aggregation uses MongoDB `$firstN`; production MongoDB must be 5.2+.
 
 Response:
 
 ```json
 {
-  "shortestPsychologists": [
+  "topPsychologists": [
     {
       "psychologistId": "660900000000000000000030",
       "psychologistName": "Specialist Name",
-      "averageLifecycleDays": 12.5,
-      "medianLifecycleDays": 10,
-      "requestCount": 4,
+      "baseScore": 75.3,
+      "scoreStatus": "scored",
+      "confidenceCoefficient": 0.8,
+      "confidenceLevel": "low",
+      "clientsWithAtLeastOneSession": 4,
+      "acceptedRequestCount": 5,
+      "acceptedRequestsWithAtLeastOneSession": 4,
+      "acceptedRequestsWithAtLeastTwoSessions": 3,
       "linkedSessionCount": 11,
-      "averageFirstSessionDelayDays": 3.5,
-      "noSessionCount": 2
+      "noSessionCount": 1,
+      "missingMetrics": [],
+      "warnings": [],
+      "metrics": {
+        "retention": {
+          "status": "available",
+          "rawValue": 5,
+          "score": 50,
+          "weight": 0.3684,
+          "contribution": 18.4,
+          "sampleSize": 5,
+          "supportingValues": {
+            "reachedSession2Count": 3,
+            "reachedSession2Percent": 60,
+            "reachedSession5Count": 2,
+            "reachedSession5Percent": 40,
+            "reachedSession10Count": 1,
+            "reachedSession10Percent": 20
+          }
+        },
+        "startRate": {
+          "status": "available",
+          "rawValue": 0.8,
+          "score": 80,
+          "weight": 0.2632,
+          "contribution": 21.1,
+          "sampleSize": 5
+        },
+        "timeToFirstSession": {
+          "status": "available",
+          "rawValue": 2,
+          "score": 95,
+          "weight": 0.2105,
+          "contribution": 20,
+          "sampleSize": 4
+        },
+        "regularity": {
+          "status": "available",
+          "rawValue": 7,
+          "score": 100,
+          "weight": 0.1579,
+          "contribution": 15.8,
+          "sampleSize": 3
+        },
+        "documentation": {
+          "status": "excluded",
+          "rawValue": null,
+          "score": null,
+          "weight": 0,
+          "contribution": null,
+          "sampleSize": 0
+        }
+      }
     }
   ],
-  "longestPsychologists": [],
+  "bottomPsychologists": [],
+  "insufficientDataPsychologists": [],
   "requestRows": [
     {
       "requestId": "661900000000000000000001",
+      "psychologistId": "660900000000000000000030",
       "psychologistName": "Specialist Name",
       "clientName": "Client Request",
       "requestCreatedAt": "2026-01-01T00:00:00.000Z",
       "firstSessionAt": "2026-01-03T00:00:00.000Z",
       "latestSessionAt": "2026-01-12T00:00:00.000Z",
       "firstSessionDelayDays": 2,
-      "lifecycleDays": 11,
+      "firstTenSessionCount": 3,
+      "firstTenMedianIntervalDays": 4.5,
       "linkedSessionCount": 3,
-      "linkStatus": "linked"
+      "linkStatus": "linked",
+      "warnings": []
     }
   ],
+  "requestRowsTotal": 1,
   "unlinkedSessionCount": 6,
-  "noSessionRequestCount": 2
+  "noSessionRequestCount": 2,
+  "scoringModel": {
+    "supportedWeights": {
+      "retention": 0.3684,
+      "startRate": 0.2632,
+      "timeToFirstSession": 0.2105,
+      "regularity": 0.1579
+    },
+    "excludedMetrics": [
+      {
+        "metric": "documentation",
+        "reason": "No independent source for completed sessions exists; recorded session rows are the only evidence a session happened."
+      }
+    ],
+    "metricDescriptors": {
+      "retention": {
+        "rawValueLabel": "median capped sessions in first 10",
+        "formula": "median(min(recordedSessionCount, 10)) / 10 * 100",
+        "explanation": "Uses the median capped recorded session count across accepted requests."
+      },
+      "startRate": {
+        "rawValueLabel": "accepted requests with first session / accepted requests",
+        "formula": "acceptedRequestsWithAtLeastOneSession / allAcceptedRequests * 100",
+        "explanation": "Measures how many accepted requests have at least one linked session."
+      },
+      "timeToFirstSession": {
+        "rawValueLabel": "median days from request creation to first session",
+        "formula": "max(50, 100 - max(0, medianDaysToFirstSession - 1) * 5)",
+        "explanation": "Uses request creation time and the first linked session. Invalid negative delays are excluded.",
+        "unavailableReason": "No accepted request has a reliable first linked session."
+      },
+      "regularity": {
+        "rawValueLabel": "median interval days between first 10 sessions",
+        "formula": "max(0, 100 - abs(specialistMedianInterval - 7) * 10)",
+        "explanation": "Uses median calendar-day intervals between consecutive sessions in each request/client first 10 sessions.",
+        "unavailableReason": "No accepted request has at least two linked sessions."
+      },
+      "documentation": {
+        "rawValueLabel": "unavailable",
+        "formula": "Future metric: recordedRequiredSessions / min(actualCompletedSessions, 10)",
+        "explanation": "Documentation score is excluded from the current weighted score.",
+        "unavailableReason": "No independent source for completed sessions exists; recorded session rows are the only evidence a session happened."
+      }
+    },
+    "confidenceThresholdClients": 5,
+    "period": {
+      "month": "2026-01",
+      "timezone": "UTC"
+    }
+  }
 }
 ```
 
@@ -2556,7 +2667,7 @@ Request:
 
 ### `GET /therapy-request-analytics/export`
 
-Admin/editor. Returns an `.xlsx` file respecting current filters. Sheets: raw requests, monthly summary, category breakdown, psychologist lifecycle, and request lifecycles.
+Admin/editor. Returns an `.xlsx` file respecting current filters. Sheets: raw requests, monthly summary, category breakdown, psychologist KPI scores, and KPI request audit.
 
 ### `POST /therapy-requests/:therapyRequestId/accept`
 

--- a/docs/ADMIN-WEB-API.md
+++ b/docs/ADMIN-WEB-API.md
@@ -1133,13 +1133,19 @@ The request-detail analytics route returns only `_id`, `descr`, and non-hidden r
 
 Inference is conservative and explainable. Automatic classification never overwrites fields marked as manually reviewed. Low-confidence values are stored as `unknown` or left review-required.
 
-Lifecycle analytics:
+KPI analytics (`GET /therapy-request-analytics/lifecycle`):
 
-- Request-level lifecycle rows show request creation, first linked session, latest linked session, first-session delay, lifecycle days, linked session count, and link status.
-- Psychologist rankings aggregate request lifecycles by average and median lifecycle days and include request count, linked session count, average first-session delay, and no-session count.
-- Sessions without deterministic request links are excluded from rankings and reported separately.
+- The route name is kept for compatibility, but the payload is KPI-based.
+- KPI scoring uses accepted requests with an assigned psychologist. Date/month filters apply to `TherapyRequest.createdAt`.
+- Time to first session uses request creation to first linked session. There is no `acceptedAt` field.
+- Only sessions linked through `TherapySession.therapyRequest` are used for KPI scoring. Unlinked sessions are excluded from scores and reported separately for cleanup.
+- Supported score weights are retention `36.84%`, start rate `26.32%`, time to first session `21.05%`, and regularity `15.79%`.
+- Documentation score is unavailable and excluded because there is no independent source for completed sessions; recorded session rows are the only evidence a session happened.
+- Confidence is informational only: `min(clientsWithAtLeastOneSession / 5, 1)`. Low confidence does not change score, ranking, or eligibility.
+- Specialists missing any supported metric get `baseScore: null`, `scoreStatus: "insufficient_data"`, and are returned outside Top 10 / Bottom 10.
+- No archived/deleted/cancelled/duplicate/test request status exists in the current schema, so those categories are not silently filtered.
 
-Export returns an `.xlsx` file respecting current filters. Sheets: raw requests, monthly summary, category breakdown, psychologist lifecycle, and request lifecycles.
+Export returns an `.xlsx` file respecting current filters. Sheets: raw requests, monthly summary, category breakdown, psychologist KPI scores, and KPI request audit.
 
 Backfill:
 

--- a/src/therapy-requests/therapy-request-analytics.service.spec.ts
+++ b/src/therapy-requests/therapy-request-analytics.service.spec.ts
@@ -1,5 +1,11 @@
-import { TherapyRequestAnalyticsService } from './therapy-request-analytics.service';
+import {
+  TherapyRequestAnalyticsService,
+  buildFiniteSessionDateExpression,
+  buildSessionCountPipeline,
+  buildSessionDatePipeline,
+} from './therapy-request-analytics.service';
 import { NotFoundException } from '@nestjs/common';
+import mongoose from 'mongoose';
 
 function chain(result: unknown) {
   return {
@@ -29,6 +35,93 @@ const id = (value: string) => ({
 });
 
 describe('TherapyRequestAnalyticsService', () => {
+  const mongoBackedIt =
+    process.env.MONGO_URL && process.env.MONGO_DBNAME ? it : it.skip;
+
+  it('builds finite-date session aggregation expressions that reject NaN', () => {
+    expect(buildFiniteSessionDateExpression()).toEqual({
+      $and: [
+        {
+          $in: [{ $type: '$dateTime' }, ['int', 'long', 'double', 'decimal']],
+        },
+        { $gt: ['$dateTime', -Infinity] },
+        { $lt: ['$dateTime', Infinity] },
+      ],
+    });
+    expect(JSON.stringify(buildFiniteSessionDateExpression())).not.toContain(
+      '$eq',
+    );
+
+    const countPipeline = buildSessionCountPipeline(['request-1']);
+    const datePipeline = buildSessionDatePipeline(['request-1']);
+    expect(countPipeline).toContainEqual({
+      $group: expect.objectContaining({
+        invalidSessionDateCount: {
+          $sum: {
+            $cond: [buildFiniteSessionDateExpression(), 0, 1],
+          },
+        },
+      }),
+    });
+    expect(datePipeline).toContainEqual({
+      $sort: { therapyRequest: 1, dateTime: 1, _id: 1 },
+    });
+    expect(datePipeline).toContainEqual({
+      $match: { $expr: buildFiniteSessionDateExpression() },
+    });
+  });
+
+  mongoBackedIt(
+    'rejects NaN session dates in a live Mongo aggregation',
+    async () => {
+      const connection = await mongoose
+        .createConnection(process.env.MONGO_URL as string, {
+          dbName: process.env.MONGO_DBNAME,
+          user: process.env.MONGO_INITDB_ROOT_USERNAME,
+          pass: process.env.MONGO_INITDB_ROOT_PASSWORD,
+        })
+        .asPromise();
+      const collection = connection.db.collection(
+        `therapy_session_nan_test_${Date.now()}`,
+      );
+      const therapyRequest = new mongoose.Types.ObjectId();
+
+      try {
+        await collection.insertMany([
+          { therapyRequest, dateTime: 100 },
+          { therapyRequest, dateTime: Number.NaN },
+          { therapyRequest, dateTime: 200 },
+        ]);
+
+        const countRows = await collection
+          .aggregate(buildSessionCountPipeline([therapyRequest]) as any[])
+          .toArray();
+        const dateRows = await collection
+          .aggregate(buildSessionDatePipeline([therapyRequest]) as any[])
+          .toArray();
+
+        expect(countRows).toEqual([
+          expect.objectContaining({
+            _id: therapyRequest,
+            linkedSessionCount: 3,
+            invalidSessionDateCount: 1,
+          }),
+        ]);
+        expect(dateRows).toEqual([
+          expect.objectContaining({
+            _id: therapyRequest,
+            firstSessionAt: 100,
+            latestSessionAt: 200,
+            firstTenSessionDates: [100, 200],
+          }),
+        ]);
+      } finally {
+        await collection.drop().catch(() => undefined);
+        await connection.close();
+      }
+    },
+  );
+
   it('returns summary from aggregation with legacy-safe review defaults', async () => {
     const aggregate = jest.fn().mockReturnValue(
       aggregateChain([
@@ -348,16 +441,30 @@ describe('TherapyRequestAnalyticsService', () => {
         distinct: jest.fn(),
       } as any,
       {
-        aggregate: jest.fn().mockReturnValue(
-          aggregateChain([
-            {
-              _id: id('request-1'),
-              firstSessionAt: new Date('2026-01-11T00:00:00Z').getTime(),
-              latestSessionAt: new Date('2026-01-21T00:00:00Z').getTime(),
-              linkedSessionCount: 2,
-            },
-          ]),
-        ),
+        aggregate: jest
+          .fn()
+          .mockReturnValueOnce(
+            aggregateChain([
+              {
+                _id: id('request-1'),
+                linkedSessionCount: 2,
+                invalidSessionDateCount: 0,
+              },
+            ]),
+          )
+          .mockReturnValueOnce(
+            aggregateChain([
+              {
+                _id: id('request-1'),
+                firstSessionAt: new Date('2026-01-11T00:00:00Z').getTime(),
+                latestSessionAt: new Date('2026-01-21T00:00:00Z').getTime(),
+                firstTenSessionDates: [
+                  new Date('2026-01-11T00:00:00Z').getTime(),
+                  new Date('2026-01-21T00:00:00Z').getTime(),
+                ],
+              },
+            ]),
+          ),
         countDocuments: jest.fn().mockReturnValue(countChain(3)),
       } as any,
       { find: jest.fn() } as any,
@@ -368,24 +475,240 @@ describe('TherapyRequestAnalyticsService', () => {
       offset: '1',
     });
 
-    expect(result.shortestPsychologists).toHaveLength(1);
-    expect(result.shortestPsychologists[0]).toMatchObject({
+    expect(result.topPsychologists).toHaveLength(1);
+    expect(result.bottomPsychologists).toEqual([]);
+    expect(result.topPsychologists[0]).toMatchObject({
       psychologistName: 'Dr One',
-      averageLifecycleDays: 20,
-      medianLifecycleDays: 20,
-      requestCount: 1,
+      baseScore: 31.5,
+      scoreStatus: 'scored',
+      confidenceCoefficient: 0.2,
+      confidenceLevel: 'low',
+      acceptedRequestCount: 3,
+      acceptedRequestsWithAtLeastOneSession: 1,
+      acceptedRequestsWithAtLeastTwoSessions: 1,
       linkedSessionCount: 2,
       noSessionCount: 2,
+      missingMetrics: [],
+      metrics: {
+        retention: expect.objectContaining({
+          rawValue: 0,
+          score: 0,
+          sampleSize: 3,
+        }),
+        startRate: expect.objectContaining({
+          rawValue: 0.3,
+          score: 33.3,
+          sampleSize: 3,
+        }),
+        timeToFirstSession: expect.objectContaining({
+          rawValue: 10,
+          score: 55,
+          sampleSize: 1,
+        }),
+        regularity: expect.objectContaining({
+          rawValue: 10,
+          score: 70,
+          sampleSize: 1,
+        }),
+        documentation: expect.objectContaining({
+          status: 'excluded',
+          score: null,
+        }),
+      },
     });
     expect(result.requestRowsTotal).toBe(3);
     expect(result.requestRows).toEqual([
       expect.objectContaining({
         requestId: 'request-2',
-        lifecycleDays: null,
+        firstTenSessionCount: 0,
+        firstTenMedianIntervalDays: null,
         linkStatus: 'no_sessions',
       }),
     ]);
     expect(result.unlinkedSessionCount).toBe(3);
+    expect(result.scoringModel.supportedWeights).toMatchObject({
+      retention: 0.3684,
+      startRate: 0.2632,
+      timeToFirstSession: 0.2105,
+      regularity: 0.1579,
+    });
+    const contributionTotal = Object.values(result.topPsychologists[0].metrics)
+      .map((metric) => metric.contribution || 0)
+      .reduce((sum, contribution) => sum + contribution, 0);
+    expect(result.topPsychologists[0].baseScore).toBe(
+      Math.round(contributionTotal * 10) / 10,
+    );
+  });
+
+  it('counts misdated linked sessions for start rate but excludes them from delay metrics', async () => {
+    const psychologist = {
+      _id: id('psychologist-1'),
+      user: { name: 'Dr One' },
+    };
+    const requests = [
+      {
+        _id: id('request-1'),
+        createdAt: new Date('2026-01-10T00:00:00Z'),
+        name: 'Client One',
+        psychologist,
+      },
+      {
+        _id: id('request-2'),
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        name: 'Client Two',
+        psychologist,
+      },
+    ];
+    const find = jest.fn().mockReturnValue(chain(requests));
+    const service = new TherapyRequestAnalyticsService(
+      {
+        find,
+        aggregate: jest.fn().mockReturnValue(aggregateChain([])),
+        distinct: jest.fn(),
+      } as any,
+      {
+        aggregate: jest
+          .fn()
+          .mockReturnValueOnce(
+            aggregateChain([
+              {
+                _id: id('request-1'),
+                linkedSessionCount: 1,
+                invalidSessionDateCount: 0,
+              },
+              {
+                _id: id('request-2'),
+                linkedSessionCount: 2,
+                invalidSessionDateCount: 0,
+              },
+            ]),
+          )
+          .mockReturnValueOnce(
+            aggregateChain([
+              {
+                _id: id('request-1'),
+                firstSessionAt: new Date('2026-01-05T00:00:00Z').getTime(),
+                latestSessionAt: new Date('2026-01-05T00:00:00Z').getTime(),
+                firstTenSessionDates: [
+                  new Date('2026-01-05T00:00:00Z').getTime(),
+                ],
+              },
+              {
+                _id: id('request-2'),
+                firstSessionAt: new Date('2026-01-02T00:00:00Z').getTime(),
+                latestSessionAt: new Date('2026-01-09T00:00:00Z').getTime(),
+                firstTenSessionDates: [
+                  new Date('2026-01-02T00:00:00Z').getTime(),
+                  new Date('2026-01-09T00:00:00Z').getTime(),
+                ],
+              },
+            ]),
+          ),
+        countDocuments: jest.fn().mockReturnValue(countChain(0)),
+      } as any,
+      { find: jest.fn() } as any,
+    );
+
+    const result = await service.getLifecycle({
+      accepted: 'false',
+      clientGender: 'female',
+    });
+
+    expect(find).toHaveBeenCalledWith({
+      clientGender: 'female',
+      accepted: true,
+    });
+    expect(result.topPsychologists[0]).toMatchObject({
+      clientsWithAtLeastOneSession: 2,
+      acceptedRequestsWithAtLeastOneSession: 2,
+      confidenceCoefficient: 0.4,
+      metrics: {
+        startRate: expect.objectContaining({
+          rawValue: 1,
+          score: 100,
+          sampleSize: 2,
+        }),
+        timeToFirstSession: expect.objectContaining({
+          rawValue: 1,
+          score: 100,
+          sampleSize: 1,
+        }),
+      },
+    });
+    expect(result.requestRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          requestId: 'request-1',
+          firstSessionDelayDays: null,
+          linkStatus: 'linked',
+          warnings: ['first_session_before_request_creation'],
+        }),
+      ]),
+    );
+  });
+
+  it('keeps valid session dates bounded while warning about invalid linked dates', async () => {
+    const psychologist = {
+      _id: id('psychologist-1'),
+      user: { name: 'Dr One' },
+    };
+    const requests = [
+      {
+        _id: id('request-1'),
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        name: 'Client One',
+        psychologist,
+      },
+    ];
+    const service = new TherapyRequestAnalyticsService(
+      {
+        find: jest.fn().mockReturnValue(chain(requests)),
+        aggregate: jest.fn().mockReturnValue(aggregateChain([])),
+        distinct: jest.fn(),
+      } as any,
+      {
+        aggregate: jest
+          .fn()
+          .mockReturnValueOnce(
+            aggregateChain([
+              {
+                _id: id('request-1'),
+                linkedSessionCount: 3,
+                invalidSessionDateCount: 1,
+              },
+            ]),
+          )
+          .mockReturnValueOnce(
+            aggregateChain([
+              {
+                _id: id('request-1'),
+                firstSessionAt: new Date('2026-01-02T00:00:00Z').getTime(),
+                latestSessionAt: new Date('2026-01-09T00:00:00Z').getTime(),
+                firstTenSessionDates: [
+                  new Date('2026-01-02T00:00:00Z').getTime(),
+                  new Date('2026-01-09T00:00:00Z').getTime(),
+                ],
+              },
+            ]),
+          ),
+        countDocuments: jest.fn().mockReturnValue(countChain(0)),
+      } as any,
+      { find: jest.fn() } as any,
+    );
+
+    const result = await service.getLifecycle({});
+
+    expect(result.requestRows).toEqual([
+      expect.objectContaining({
+        requestId: 'request-1',
+        firstSessionDelayDays: 1,
+        firstTenSessionCount: 2,
+        firstTenMedianIntervalDays: 7,
+        latestSessionAt: new Date('2026-01-09T00:00:00Z'),
+        linkedSessionCount: 3,
+        warnings: ['invalid_session_date_ignored'],
+      }),
+    ]);
   });
 
   it('normalizes oversized lifecycle row offsets to the last available page', async () => {
@@ -437,6 +760,14 @@ describe('TherapyRequestAnalyticsService', () => {
     });
 
     expect(result.requestRowsTotal).toBe(3);
+    expect(result.topPsychologists).toHaveLength(0);
+    expect(result.insufficientDataPsychologists).toEqual([
+      expect.objectContaining({
+        psychologistName: 'Dr One',
+        baseScore: null,
+        missingMetrics: ['timeToFirstSession', 'regularity'],
+      }),
+    ]);
     expect(result.requestRows).toEqual([
       expect.objectContaining({
         requestId: 'request-3',
@@ -463,6 +794,6 @@ describe('TherapyRequestAnalyticsService', () => {
 
     expect(Buffer.isBuffer(buffer)).toBe(true);
     expect(buffer.subarray(0, 2).toString()).toBe('PK');
-    expect(find).toHaveBeenCalledTimes(1);
+    expect(find).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/therapy-requests/therapy-request-analytics.service.ts
+++ b/src/therapy-requests/therapy-request-analytics.service.ts
@@ -21,18 +21,67 @@ import {
 } from './schemas/therapy-request.schema';
 import {
   PaginatedResponse,
+  TherapyRequestAnalyticsMetricBreakdown,
+  TherapyRequestAnalyticsMetricKey,
   TherapyRequestAnalyticsFiltersResponse,
   TherapyRequestAnalyticsLifecycleResponse,
+  TherapyRequestAnalyticsPsychologistLifecycle,
   TherapyRequestAnalyticsQuery,
   TherapyRequestAnalyticsRequestDetails,
   TherapyRequestAnalyticsRequest,
   TherapyRequestAnalyticsRequestsResponse,
   TherapyRequestAnalyticsSummaryResponse,
+  TherapyRequestAnalyticsWarningKey,
 } from './types/therapy-request-analytics.types';
 
 const dayMs = 1000 * 60 * 60 * 24;
 const DEFAULT_REQUEST_LIMIT = 20;
 const MAX_REQUEST_LIMIT = 1000;
+const CONFIDENCE_THRESHOLD_CLIENTS = 5;
+const DOCUMENTATION_UNAVAILABLE_REASON =
+  'No independent source for completed sessions exists; recorded session rows are the only evidence a session happened.';
+const SUPPORTED_KPI_WEIGHTS: Record<TherapyRequestAnalyticsMetricKey, number> =
+  {
+    retention: 0.3684,
+    startRate: 0.2632,
+    timeToFirstSession: 0.2105,
+    regularity: 0.1579,
+  };
+const METRIC_DESCRIPTORS = {
+  retention: {
+    rawValueLabel: 'median capped sessions in first 10',
+    formula: 'median(min(recordedSessionCount, 10)) / 10 * 100',
+    explanation:
+      'Uses the median capped recorded session count across accepted requests.',
+  },
+  startRate: {
+    rawValueLabel: 'accepted requests with first session / accepted requests',
+    formula: 'acceptedRequestsWithAtLeastOneSession / allAcceptedRequests * 100',
+    explanation:
+      'Measures how many accepted requests have at least one linked session.',
+  },
+  timeToFirstSession: {
+    rawValueLabel: 'median days from request creation to first session',
+    formula: 'max(50, 100 - max(0, medianDaysToFirstSession - 1) * 5)',
+    explanation:
+      'Uses request creation time and the first linked session. Invalid negative delays are excluded.',
+    unavailableReason: 'No accepted request has a reliable first linked session.',
+  },
+  regularity: {
+    rawValueLabel: 'median interval days between first 10 sessions',
+    formula: 'max(0, 100 - abs(specialistMedianInterval - 7) * 10)',
+    explanation:
+      'Uses median calendar-day intervals between consecutive sessions in each request/client first 10 sessions.',
+    unavailableReason: 'No accepted request has at least two linked sessions.',
+  },
+  documentation: {
+    rawValueLabel: 'unavailable',
+    formula:
+      'Future metric: recordedRequiredSessions / min(actualCompletedSessions, 10)',
+    explanation: 'Documentation score is excluded from the current weighted score.',
+    unavailableReason: DOCUMENTATION_UNAVAILABLE_REASON,
+  },
+} as const;
 
 function parseBoolean(value: unknown): boolean | undefined {
   if (typeof value === 'boolean') {
@@ -178,6 +227,14 @@ function daysBetween(from?: Date | number, to?: Date | number): number | null {
   return Math.round(((toMs - fromMs) / dayMs) * 10) / 10;
 }
 
+function isValidTimestamp(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
 function median(values: number[]): number {
   if (!values.length) {
     return 0;
@@ -186,21 +243,9 @@ function median(values: number[]): number {
   const sorted = [...values].sort((a, b) => a - b);
   const middle = Math.floor(sorted.length / 2);
   if (sorted.length % 2 === 0) {
-    return Math.round(((sorted[middle - 1] + sorted[middle]) / 2) * 10) / 10;
+    return round1((sorted[middle - 1] + sorted[middle]) / 2);
   }
   return sorted[middle];
-}
-
-function average(values: number[]): number {
-  if (!values.length) {
-    return 0;
-  }
-
-  return (
-    Math.round(
-      (values.reduce((sum, value) => sum + value, 0) / values.length) * 10,
-    ) / 10
-  );
 }
 
 type DateRangeFilter = {
@@ -215,6 +260,64 @@ type SummaryInputRequest = Pick<
   ProjectedTherapyRequest,
   'createdAt' | 'clientGender' | 'requestCategory' | 'analyticsReviewRequired'
 >;
+
+type RequestSessionSummary = {
+  firstSessionAt?: number;
+  latestSessionAt?: number;
+  linkedSessionCount: number;
+  firstTenSessionDates: number[];
+  invalidSessionDateCount: number;
+};
+
+export function buildFiniteSessionDateExpression(field = '$dateTime') {
+  return {
+    $and: [
+      {
+        $in: [{ $type: field }, ['int', 'long', 'double', 'decimal']],
+      },
+      { $gt: [field, -Infinity] },
+      { $lt: [field, Infinity] },
+    ],
+  };
+}
+
+export function buildSessionCountPipeline(requestIds: unknown[]) {
+  const validDateExpression = buildFiniteSessionDateExpression();
+  return [
+    { $match: { therapyRequest: { $in: requestIds } } },
+    {
+      $group: {
+        _id: '$therapyRequest',
+        linkedSessionCount: { $sum: 1 },
+        invalidSessionDateCount: {
+          $sum: {
+            $cond: [validDateExpression, 0, 1],
+          },
+        },
+      },
+    },
+  ];
+}
+
+export function buildSessionDatePipeline(requestIds: unknown[]) {
+  return [
+    { $match: { therapyRequest: { $in: requestIds } } },
+    { $sort: { therapyRequest: 1, dateTime: 1, _id: 1 } },
+    { $match: { $expr: buildFiniteSessionDateExpression() } },
+    {
+      $group: {
+        _id: '$therapyRequest',
+        firstSessionAt: { $first: '$dateTime' },
+        latestSessionAt: { $last: '$dateTime' },
+        firstTenSessionDates: {
+          $firstN: { input: '$dateTime', n: 10 },
+        },
+      },
+    },
+  ];
+}
+
+type KpiRequestRow = TherapyRequestAnalyticsLifecycleResponse['requestRows'][0];
 
 @Injectable()
 export class TherapyRequestAnalyticsService {
@@ -363,44 +466,61 @@ export class TherapyRequestAnalyticsService {
     query: TherapyRequestAnalyticsQuery,
   ): Promise<TherapyRequestAnalyticsLifecycleResponse> {
     const requests = await this.findLifecycleRequests(query);
-    return this.buildLifecycle(query, requests);
+    return this.buildKpiLifecycle(query, requests);
   }
 
-  private async buildLifecycle(
+  private async buildKpiLifecycle(
     query: TherapyRequestAnalyticsQuery,
     requests: ProjectedTherapyRequest[],
     options: { paginateRows?: boolean } = { paginateRows: true },
   ): Promise<TherapyRequestAnalyticsLifecycleResponse> {
     const requestIds = requests.map((request) => request._id);
-    const sessionRows = requestIds.length
-      ? await this.therapySessionModel
-          .aggregate([
-            { $match: { therapyRequest: { $in: requestIds } } },
-            {
-              $group: {
-                _id: '$therapyRequest',
-                firstSessionAt: { $min: '$dateTime' },
-                latestSessionAt: { $max: '$dateTime' },
-                linkedSessionCount: { $sum: 1 },
-              },
-            },
-          ])
-          .exec()
-      : [];
+    const [sessionCountRows, sessionDateRows] = requestIds.length
+      ? await Promise.all([
+          this.therapySessionModel
+            .aggregate(buildSessionCountPipeline(requestIds) as any[])
+            .exec(),
+          this.therapySessionModel
+            .aggregate(buildSessionDatePipeline(requestIds) as any[])
+            .exec(),
+        ])
+      : [[], []];
 
-    const sessionsByRequest = new Map<
-      string,
-      {
-        firstSessionAt?: number;
-        latestSessionAt?: number;
-        linkedSessionCount: number;
-      }
-    >();
-    for (const row of sessionRows) {
+    const sessionsByRequest = new Map<string, RequestSessionSummary>();
+    for (const row of sessionCountRows) {
       const requestId = toId(row._id);
       if (requestId) {
-        sessionsByRequest.set(requestId, row);
+        sessionsByRequest.set(requestId, {
+          linkedSessionCount: row.linkedSessionCount || 0,
+          firstTenSessionDates: [],
+          invalidSessionDateCount: row.invalidSessionDateCount || 0,
+        });
       }
+    }
+    for (const row of sessionDateRows) {
+      const requestId = toId(row._id);
+      if (!requestId) {
+        continue;
+      }
+
+      const summary = sessionsByRequest.get(requestId) || {
+        linkedSessionCount: 0,
+        firstTenSessionDates: [],
+        invalidSessionDateCount: 0,
+      };
+      const firstTenSessionDates = (
+        (row.firstTenSessionDates || []) as unknown[]
+      ).filter(isValidTimestamp);
+      sessionsByRequest.set(requestId, {
+        ...summary,
+        firstSessionAt: isValidTimestamp(row.firstSessionAt)
+          ? row.firstSessionAt
+          : undefined,
+        latestSessionAt: isValidTimestamp(row.latestSessionAt)
+          ? row.latestSessionAt
+          : undefined,
+        firstTenSessionDates,
+      });
     }
 
     const requestRows = requests.map((request) => {
@@ -413,6 +533,29 @@ export class TherapyRequestAnalyticsService {
         : undefined;
       const psychologistId = toId(request.psychologist);
       const linkedSessionCount = requestSessions?.linkedSessionCount || 0;
+      const firstTenSessionDates = requestSessions?.firstTenSessionDates || [];
+      const firstSessionDelayDays = daysBetween(
+        request.createdAt,
+        firstSessionAt,
+      );
+      const warnings: TherapyRequestAnalyticsWarningKey[] = [];
+      if (requestSessions?.invalidSessionDateCount) {
+        warnings.push('invalid_session_date_ignored');
+      }
+      if (
+        firstSessionAt &&
+        firstSessionDelayDays !== null &&
+        firstSessionDelayDays < 0
+      ) {
+        warnings.push('first_session_before_request_creation');
+      }
+
+      const firstTenIntervals = firstTenSessionDates
+        .slice(1)
+        .map((dateTime, index) =>
+          daysBetween(firstTenSessionDates[index], dateTime),
+        )
+        .filter((value): value is number => typeof value === 'number');
 
       return {
         requestId: request._id.toString(),
@@ -422,12 +565,19 @@ export class TherapyRequestAnalyticsService {
         requestCreatedAt: request.createdAt,
         firstSessionAt,
         latestSessionAt,
-        firstSessionDelayDays: daysBetween(request.createdAt, firstSessionAt),
-        lifecycleDays: daysBetween(request.createdAt, latestSessionAt),
+        firstSessionDelayDays:
+          firstSessionDelayDays !== null && firstSessionDelayDays >= 0
+            ? firstSessionDelayDays
+            : null,
+        firstTenSessionCount: firstTenSessionDates.length,
+        firstTenMedianIntervalDays: firstTenIntervals.length
+          ? median(firstTenIntervals)
+          : null,
         linkedSessionCount,
         linkStatus: linkedSessionCount
           ? ('linked' as const)
           : ('no_sessions' as const),
+        warnings,
       };
     });
 
@@ -442,33 +592,13 @@ export class TherapyRequestAnalyticsService {
       rowsByPsychologist.set(row.psychologistId, list);
     }
 
-    const rankings = Array.from(rowsByPsychologist.entries())
-      .map(([psychologistId, rows]) => {
-        const linkedRows = rows.filter(
-          (row) => typeof row.lifecycleDays === 'number',
-        );
-        const lifecycleDays = linkedRows.map((row) => row.lifecycleDays);
-        const firstSessionDelayDays = linkedRows
-          .map((row) => row.firstSessionDelayDays)
-          .filter((value): value is number => typeof value === 'number');
-
-        return {
-          psychologistId,
-          psychologistName: rows[0]?.psychologistName || psychologistId,
-          averageLifecycleDays: average(lifecycleDays),
-          medianLifecycleDays: median(lifecycleDays),
-          requestCount: linkedRows.length,
-          linkedSessionCount: linkedRows.reduce(
-            (sum, row) => sum + row.linkedSessionCount,
-            0,
-          ),
-          averageFirstSessionDelayDays: average(firstSessionDelayDays),
-          noSessionCount: rows.filter((row) => row.linkStatus === 'no_sessions')
-            .length,
-          insufficientData: linkedRows.length === 0,
-        };
-      })
-      .filter((row) => !row.insufficientData);
+    const specialists = Array.from(rowsByPsychologist.entries()).map(
+      ([psychologistId, rows]) =>
+        this.buildSpecialistKpi(psychologistId, rows),
+    );
+    const scoredSpecialists = specialists.filter(
+      (row) => row.scoreStatus === 'scored' && row.baseScore !== null,
+    );
 
     const unlinkedSessionCount = await this.countUnlinkedSessions(query);
     const requestRowsTotal = requestRows.length;
@@ -482,28 +612,282 @@ export class TherapyRequestAnalyticsService {
       options.paginateRows === false
         ? requestRows
         : requestRows.slice(rowOffset, rowOffset + rowLimit);
+    const topPsychologists = [...scoredSpecialists]
+      .sort((a, b) => this.sortScoredSpecialists(a, b, 'desc'))
+      .slice(0, 10);
+    const bottomPsychologists =
+      scoredSpecialists.length > 10
+        ? [...scoredSpecialists]
+            .sort((a, b) => this.sortScoredSpecialists(a, b, 'asc'))
+            .filter(
+              (row) =>
+                !topPsychologists.some(
+                  (topRow) => topRow.psychologistId === row.psychologistId,
+                ),
+            )
+            .slice(0, 10)
+        : [];
 
     return {
-      shortestPsychologists: [...rankings]
-        .sort((a, b) => a.averageLifecycleDays - b.averageLifecycleDays)
-        .slice(0, 10),
-      longestPsychologists: [...rankings]
-        .sort((a, b) => b.averageLifecycleDays - a.averageLifecycleDays)
-        .slice(0, 10),
+      topPsychologists,
+      bottomPsychologists,
+      insufficientDataPsychologists: specialists
+        .filter((row) => row.scoreStatus === 'insufficient_data')
+        .sort((a, b) => this.sortSpecialistsByName(a, b)),
       requestRows: paginatedRequestRows,
       requestRowsTotal,
       unlinkedSessionCount,
       noSessionRequestCount: requestRows.filter(
         (row) => row.linkStatus === 'no_sessions',
       ).length,
+      scoringModel: this.buildScoringModel(query),
+    };
+  }
+
+  private buildSpecialistKpi(
+    psychologistId: string,
+    rows: KpiRequestRow[],
+  ): TherapyRequestAnalyticsPsychologistLifecycle {
+    const acceptedRequestCount = rows.length;
+    const rowsWithLinkedSession = rows.filter(
+      (row) => row.linkedSessionCount > 0,
+    );
+    const rowsWithReliableFirstSession = rows.filter(
+      (row) => row.firstSessionAt && row.firstSessionDelayDays !== null,
+    );
+    const rowsWithTwoSessions = rows.filter(
+      (row) => row.firstTenSessionCount >= 2,
+    );
+    const linkedSessionCount = rows.reduce(
+      (sum, row) => sum + row.linkedSessionCount,
+      0,
+    );
+    const noSessionCount = rows.filter((row) => row.linkedSessionCount === 0)
+      .length;
+    const clientsWithAtLeastOneSession = rowsWithLinkedSession.length;
+    const confidenceCoefficient = round1(
+      Math.min(clientsWithAtLeastOneSession / CONFIDENCE_THRESHOLD_CLIENTS, 1),
+    );
+    const confidenceLevel =
+      clientsWithAtLeastOneSession >= CONFIDENCE_THRESHOLD_CLIENTS
+        ? ('high' as const)
+        : ('low' as const);
+
+    const cappedSessionCounts = rows.map((row) =>
+      Math.min(row.linkedSessionCount, 10),
+    );
+    const medianSessions = median(cappedSessionCounts);
+    const retentionScore = round1((medianSessions / 10) * 100);
+    const reachedSession2Count = rows.filter(
+      (row) => row.linkedSessionCount >= 2,
+    ).length;
+    const reachedSession5Count = rows.filter(
+      (row) => row.linkedSessionCount >= 5,
+    ).length;
+    const reachedSession10Count = rows.filter(
+      (row) => row.linkedSessionCount >= 10,
+    ).length;
+    const retentionSupportingValues = {
+      reachedSession2Count,
+      reachedSession2Percent: round1(
+        (reachedSession2Count / acceptedRequestCount) * 100,
+      ),
+      reachedSession5Count,
+      reachedSession5Percent: round1(
+        (reachedSession5Count / acceptedRequestCount) * 100,
+      ),
+      reachedSession10Count,
+      reachedSession10Percent: round1(
+        (reachedSession10Count / acceptedRequestCount) * 100,
+      ),
+    };
+
+    const startRate = rowsWithLinkedSession.length / acceptedRequestCount;
+    const startRateScore = round1(startRate * 100);
+
+    const validFirstSessionDelays = rowsWithReliableFirstSession
+      .map((row) => row.firstSessionDelayDays)
+      .filter((value): value is number => typeof value === 'number');
+    const medianDaysToFirstSession = validFirstSessionDelays.length
+      ? median(validFirstSessionDelays)
+      : null;
+    const timeToFirstSessionScore =
+      medianDaysToFirstSession === null
+        ? null
+        : round1(
+            Math.max(50, 100 - Math.max(0, medianDaysToFirstSession - 1) * 5),
+          );
+
+    const clientMedianIntervals = rowsWithTwoSessions
+      .map((row) => row.firstTenMedianIntervalDays)
+      .filter((value): value is number => typeof value === 'number');
+    const specialistMedianInterval = clientMedianIntervals.length
+      ? median(clientMedianIntervals)
+      : null;
+    const regularityScore =
+      specialistMedianInterval === null
+        ? null
+        : round1(Math.max(0, 100 - Math.abs(specialistMedianInterval - 7) * 10));
+
+    const metrics = {
+      retention: this.buildMetric({
+        status: acceptedRequestCount > 0 ? 'available' : 'unavailable',
+        rawValue: acceptedRequestCount > 0 ? medianSessions : null,
+        score: acceptedRequestCount > 0 ? retentionScore : null,
+        metric: 'retention',
+        sampleSize: acceptedRequestCount,
+        supportingValues: retentionSupportingValues,
+      }),
+      startRate: this.buildMetric({
+        status: acceptedRequestCount > 0 ? 'available' : 'unavailable',
+        rawValue: acceptedRequestCount > 0 ? round1(startRate) : null,
+        score: acceptedRequestCount > 0 ? startRateScore : null,
+        metric: 'startRate',
+        sampleSize: acceptedRequestCount,
+      }),
+      timeToFirstSession: this.buildMetric({
+        status: medianDaysToFirstSession === null ? 'unavailable' : 'available',
+        rawValue: medianDaysToFirstSession,
+        score: timeToFirstSessionScore,
+        metric: 'timeToFirstSession',
+        sampleSize: rowsWithReliableFirstSession.length,
+      }),
+      regularity: this.buildMetric({
+        status: specialistMedianInterval === null ? 'unavailable' : 'available',
+        rawValue: specialistMedianInterval,
+        score: regularityScore,
+        metric: 'regularity',
+        sampleSize: rowsWithTwoSessions.length,
+      }),
+      documentation: this.buildMetric({
+        status: 'excluded',
+        rawValue: null,
+        score: null,
+        metric: undefined,
+        weight: 0,
+        sampleSize: 0,
+      }),
+    };
+
+    const missingMetrics = (Object.keys(SUPPORTED_KPI_WEIGHTS) as Array<
+      TherapyRequestAnalyticsMetricKey
+    >).filter((metric) => metrics[metric].status !== 'available');
+    const baseScore = missingMetrics.length
+      ? null
+      : round1(
+          (Object.keys(SUPPORTED_KPI_WEIGHTS) as Array<
+            TherapyRequestAnalyticsMetricKey
+          >).reduce(
+            (sum, metric) => sum + (metrics[metric].contribution || 0),
+            0,
+          ),
+        );
+
+    return {
+      psychologistId,
+      psychologistName: rows[0]?.psychologistName || psychologistId,
+      baseScore,
+      scoreStatus: baseScore === null ? 'insufficient_data' : 'scored',
+      confidenceCoefficient,
+      confidenceLevel,
+      clientsWithAtLeastOneSession,
+      acceptedRequestCount,
+      acceptedRequestsWithAtLeastOneSession: rowsWithLinkedSession.length,
+      acceptedRequestsWithAtLeastTwoSessions: rowsWithTwoSessions.length,
+      linkedSessionCount,
+      noSessionCount,
+      missingMetrics,
+      warnings: Array.from(new Set(rows.flatMap((row) => row.warnings))),
+      metrics,
+    };
+  }
+
+  private buildMetric({
+    status,
+    rawValue,
+    score,
+    metric,
+    weight,
+    sampleSize,
+    supportingValues,
+  }: {
+    status: TherapyRequestAnalyticsMetricBreakdown['status'];
+    rawValue: number | null;
+    score: number | null;
+    metric?: TherapyRequestAnalyticsMetricKey;
+    weight?: number;
+    sampleSize: number;
+    supportingValues?: Record<string, number>;
+  }): TherapyRequestAnalyticsMetricBreakdown {
+    const resolvedWeight =
+      typeof weight === 'number' ? weight : metric ? SUPPORTED_KPI_WEIGHTS[metric] : 0;
+
+    return {
+      status,
+      rawValue,
+      score,
+      weight: resolvedWeight,
+      contribution:
+        status === 'available' && score !== null
+          ? round1(score * resolvedWeight)
+          : null,
+      sampleSize,
+      ...(supportingValues ? { supportingValues } : {}),
+    };
+  }
+
+  private sortScoredSpecialists(
+    a: TherapyRequestAnalyticsPsychologistLifecycle,
+    b: TherapyRequestAnalyticsPsychologistLifecycle,
+    direction: 'asc' | 'desc',
+  ): number {
+    const scoreA = a.baseScore || 0;
+    const scoreB = b.baseScore || 0;
+    if (scoreA !== scoreB) {
+      return direction === 'asc' ? scoreA - scoreB : scoreB - scoreA;
+    }
+
+    return this.sortSpecialistsByName(a, b);
+  }
+
+  private sortSpecialistsByName(
+    a: TherapyRequestAnalyticsPsychologistLifecycle,
+    b: TherapyRequestAnalyticsPsychologistLifecycle,
+  ): number {
+    return (
+      a.psychologistName.localeCompare(b.psychologistName) ||
+      a.psychologistId.localeCompare(b.psychologistId)
+    );
+  }
+
+  private buildScoringModel(query: TherapyRequestAnalyticsQuery) {
+    return {
+      supportedWeights: SUPPORTED_KPI_WEIGHTS,
+      excludedMetrics: [
+        {
+          metric: 'documentation' as const,
+          reason: DOCUMENTATION_UNAVAILABLE_REASON,
+        },
+      ],
+      metricDescriptors: METRIC_DESCRIPTORS,
+      confidenceThresholdClients: CONFIDENCE_THRESHOLD_CLIENTS,
+      period: {
+        ...(query.startDate ? { startDate: query.startDate } : {}),
+        ...(query.endDate ? { endDate: query.endDate } : {}),
+        ...(query.month ? { month: query.month } : {}),
+        timezone: 'UTC' as const,
+      },
     };
   }
 
   async exportXlsx(query: TherapyRequestAnalyticsQuery): Promise<Buffer> {
-    const requests = await this.findRequests(query, { capped: false });
+    const [requests, kpiRequests] = await Promise.all([
+      this.findRequests(query, { capped: false }),
+      this.findLifecycleRequests(query),
+    ]);
     const [summary, lifecycle] = await Promise.all([
       this.buildSummaryFromRequests(requests),
-      this.buildLifecycle(query, requests, { paginateRows: false }),
+      this.buildKpiLifecycle(query, kpiRequests, { paginateRows: false }),
     ]);
     const workbook = new ExcelJS.Workbook();
     workbook.creator = 'DOM Admin';
@@ -559,37 +943,133 @@ export class TherapyRequestAnalyticsService {
     ];
     summary.categoryBreakdown.forEach((row) => categorySheet.addRow(row));
 
-    const psychologistSheet = workbook.addWorksheet('Psychologist lifecycle');
+    const psychologistSheet = workbook.addWorksheet('Psychologist KPI scores');
     psychologistSheet.columns = [
-      { header: 'Group', key: 'group', width: 12 },
+      { header: 'Group', key: 'group', width: 18 },
       { header: 'Psychologist', key: 'psychologistName', width: 28 },
+      { header: 'Base Score', key: 'baseScore', width: 14 },
+      { header: 'Score Status', key: 'scoreStatus', width: 18 },
       {
-        header: 'Average Lifecycle Days',
-        key: 'averageLifecycleDays',
+        header: 'Confidence Coefficient',
+        key: 'confidenceCoefficient',
         width: 24,
       },
+      { header: 'Confidence Level', key: 'confidenceLevel', width: 20 },
       {
-        header: 'Median Lifecycle Days',
-        key: 'medianLifecycleDays',
-        width: 24,
+        header: 'Clients With First Session',
+        key: 'clientsWithAtLeastOneSession',
+        width: 28,
       },
-      { header: 'Request Count', key: 'requestCount', width: 16 },
+      { header: 'Accepted Requests', key: 'acceptedRequestCount', width: 20 },
+      {
+        header: 'Requests With First Session',
+        key: 'acceptedRequestsWithAtLeastOneSession',
+        width: 28,
+      },
+      {
+        header: 'Requests With 2+ Sessions',
+        key: 'acceptedRequestsWithAtLeastTwoSessions',
+        width: 28,
+      },
       { header: 'Linked Sessions', key: 'linkedSessionCount', width: 18 },
-      {
-        header: 'Average First Delay',
-        key: 'averageFirstSessionDelayDays',
-        width: 22,
-      },
       { header: 'No Session Count', key: 'noSessionCount', width: 18 },
+      { header: 'Retention Raw', key: 'retentionRaw', width: 18 },
+      { header: 'Retention Score', key: 'retentionScore', width: 18 },
+      { header: 'Retention Weight', key: 'retentionWeight', width: 18 },
+      {
+        header: 'Retention Contribution',
+        key: 'retentionContribution',
+        width: 24,
+      },
+      { header: 'Start Rate Raw', key: 'startRateRaw', width: 18 },
+      { header: 'Start Rate Score', key: 'startRateScore', width: 18 },
+      { header: 'Start Rate Weight', key: 'startRateWeight', width: 20 },
+      {
+        header: 'Start Rate Contribution',
+        key: 'startRateContribution',
+        width: 26,
+      },
+      {
+        header: 'Time To First Session Raw',
+        key: 'timeToFirstSessionRaw',
+        width: 28,
+      },
+      {
+        header: 'Time To First Session Score',
+        key: 'timeToFirstSessionScore',
+        width: 30,
+      },
+      {
+        header: 'Time To First Session Weight',
+        key: 'timeToFirstSessionWeight',
+        width: 30,
+      },
+      {
+        header: 'Time To First Session Contribution',
+        key: 'timeToFirstSessionContribution',
+        width: 36,
+      },
+      { header: 'Regularity Raw', key: 'regularityRaw', width: 18 },
+      { header: 'Regularity Score', key: 'regularityScore', width: 20 },
+      { header: 'Regularity Weight', key: 'regularityWeight', width: 22 },
+      {
+        header: 'Regularity Contribution',
+        key: 'regularityContribution',
+        width: 26,
+      },
+      {
+        header: 'Documentation Status',
+        key: 'documentationStatus',
+        width: 24,
+      },
+      {
+        header: 'Documentation Reason',
+        key: 'documentationReason',
+        width: 64,
+      },
+      { header: 'Missing Metrics', key: 'missingMetrics', width: 30 },
+      { header: 'Warnings', key: 'warnings', width: 40 },
     ];
-    lifecycle.shortestPsychologists.forEach((row) =>
-      psychologistSheet.addRow({ group: 'shortest', ...row }),
+    const addPsychologistRow = (
+      group: string,
+      row: TherapyRequestAnalyticsPsychologistLifecycle,
+    ) =>
+      psychologistSheet.addRow({
+        group,
+        ...row,
+        retentionRaw: row.metrics.retention.rawValue,
+        retentionScore: row.metrics.retention.score,
+        retentionWeight: row.metrics.retention.weight,
+        retentionContribution: row.metrics.retention.contribution,
+        startRateRaw: row.metrics.startRate.rawValue,
+        startRateScore: row.metrics.startRate.score,
+        startRateWeight: row.metrics.startRate.weight,
+        startRateContribution: row.metrics.startRate.contribution,
+        timeToFirstSessionRaw: row.metrics.timeToFirstSession.rawValue,
+        timeToFirstSessionScore: row.metrics.timeToFirstSession.score,
+        timeToFirstSessionWeight: row.metrics.timeToFirstSession.weight,
+        timeToFirstSessionContribution:
+          row.metrics.timeToFirstSession.contribution,
+        regularityRaw: row.metrics.regularity.rawValue,
+        regularityScore: row.metrics.regularity.score,
+        regularityWeight: row.metrics.regularity.weight,
+        regularityContribution: row.metrics.regularity.contribution,
+        documentationStatus: row.metrics.documentation.status,
+        documentationReason:
+          lifecycle.scoringModel.metricDescriptors.documentation
+            .unavailableReason,
+        missingMetrics: row.missingMetrics.join(', '),
+        warnings: row.warnings.join(', '),
+      });
+    lifecycle.topPsychologists.forEach((row) => addPsychologistRow('top', row));
+    lifecycle.bottomPsychologists.forEach((row) =>
+      addPsychologistRow('bottom', row),
     );
-    lifecycle.longestPsychologists.forEach((row) =>
-      psychologistSheet.addRow({ group: 'longest', ...row }),
+    lifecycle.insufficientDataPsychologists.forEach((row) =>
+      addPsychologistRow('insufficient_data', row),
     );
 
-    const requestLifecycleSheet = workbook.addWorksheet('Request lifecycles');
+    const requestLifecycleSheet = workbook.addWorksheet('KPI request audit');
     requestLifecycleSheet.columns = [
       { header: 'Request ID', key: 'requestId', width: 28 },
       { header: 'Psychologist', key: 'psychologistName', width: 28 },
@@ -598,11 +1078,25 @@ export class TherapyRequestAnalyticsService {
       { header: 'First Session At', key: 'firstSessionAt', width: 22 },
       { header: 'Latest Session At', key: 'latestSessionAt', width: 22 },
       { header: 'First Delay Days', key: 'firstSessionDelayDays', width: 18 },
-      { header: 'Lifecycle Days', key: 'lifecycleDays', width: 18 },
-      { header: 'Linked Sessions', key: 'linkedSessionCount', width: 18 },
+      {
+        header: 'All Sessions',
+        key: 'linkedSessionCount',
+        width: 18,
+      },
+      {
+        header: 'First 10 Median Interval Days',
+        key: 'firstTenMedianIntervalDays',
+        width: 32,
+      },
       { header: 'Link Status', key: 'linkStatus', width: 16 },
+      { header: 'Warnings', key: 'warnings', width: 40 },
     ];
-    lifecycle.requestRows.forEach((row) => requestLifecycleSheet.addRow(row));
+    lifecycle.requestRows.forEach((row) =>
+      requestLifecycleSheet.addRow({
+        ...row,
+        warnings: row.warnings.join(', '),
+      }),
+    );
 
     const buffer = await workbook.xlsx.writeBuffer();
     return Buffer.from(buffer);
@@ -645,9 +1139,16 @@ export class TherapyRequestAnalyticsService {
   private async findLifecycleRequests(
     query: TherapyRequestAnalyticsQuery,
   ): Promise<ProjectedTherapyRequest[]> {
+    const lifecycleQuery = { ...query };
+    delete lifecycleQuery.accepted;
+    const filter = {
+      ...this.buildRequestFilter(lifecycleQuery),
+      accepted: true,
+    };
+
     return this.therapyRequestModel
-      .find(this.buildRequestFilter(query))
-      .select('_id createdAt name psychologist')
+      .find(filter)
+      .select('_id createdAt name accepted psychologist')
       .populate({
         path: 'psychologist',
         select: '_id user',

--- a/src/therapy-requests/types/therapy-request-analytics.types.ts
+++ b/src/therapy-requests/types/therapy-request-analytics.types.ts
@@ -91,30 +91,94 @@ export interface TherapyRequestAnalyticsLifecycleRow {
   firstSessionAt?: Date;
   latestSessionAt?: Date;
   firstSessionDelayDays: number | null;
-  lifecycleDays: number | null;
+  firstTenSessionCount: number;
+  firstTenMedianIntervalDays: number | null;
   linkedSessionCount: number;
   linkStatus: 'linked' | 'no_sessions';
+  warnings: TherapyRequestAnalyticsWarningKey[];
+}
+
+export type TherapyRequestAnalyticsWarningKey =
+  | 'invalid_session_date_ignored'
+  | 'first_session_before_request_creation';
+
+export type TherapyRequestAnalyticsMetricKey =
+  | 'retention'
+  | 'startRate'
+  | 'timeToFirstSession'
+  | 'regularity';
+
+export type TherapyRequestAnalyticsMetricDescriptorKey =
+  | TherapyRequestAnalyticsMetricKey
+  | 'documentation';
+
+export interface TherapyRequestAnalyticsMetricDescriptor {
+  rawValueLabel: string;
+  formula: string;
+  explanation: string;
+  unavailableReason?: string;
+}
+
+export interface TherapyRequestAnalyticsMetricBreakdown {
+  status: 'available' | 'unavailable' | 'excluded';
+  rawValue: number | null;
+  score: number | null;
+  weight: number;
+  contribution: number | null;
+  sampleSize: number;
+  supportingValues?: Record<string, number>;
 }
 
 export interface TherapyRequestAnalyticsPsychologistLifecycle {
   psychologistId: string;
   psychologistName: string;
-  averageLifecycleDays: number;
-  medianLifecycleDays: number;
-  requestCount: number;
+  baseScore: number | null;
+  scoreStatus: 'scored' | 'insufficient_data';
+  confidenceCoefficient: number;
+  confidenceLevel: 'high' | 'low';
+  clientsWithAtLeastOneSession: number;
+  acceptedRequestCount: number;
+  acceptedRequestsWithAtLeastOneSession: number;
+  acceptedRequestsWithAtLeastTwoSessions: number;
   linkedSessionCount: number;
-  averageFirstSessionDelayDays: number;
   noSessionCount: number;
-  insufficientData: boolean;
+  missingMetrics: TherapyRequestAnalyticsMetricKey[];
+  warnings: TherapyRequestAnalyticsWarningKey[];
+  metrics: {
+    retention: TherapyRequestAnalyticsMetricBreakdown;
+    startRate: TherapyRequestAnalyticsMetricBreakdown;
+    timeToFirstSession: TherapyRequestAnalyticsMetricBreakdown;
+    regularity: TherapyRequestAnalyticsMetricBreakdown;
+    documentation: TherapyRequestAnalyticsMetricBreakdown;
+  };
 }
 
 export interface TherapyRequestAnalyticsLifecycleResponse {
-  shortestPsychologists: TherapyRequestAnalyticsPsychologistLifecycle[];
-  longestPsychologists: TherapyRequestAnalyticsPsychologistLifecycle[];
+  topPsychologists: TherapyRequestAnalyticsPsychologistLifecycle[];
+  bottomPsychologists: TherapyRequestAnalyticsPsychologistLifecycle[];
+  insufficientDataPsychologists: TherapyRequestAnalyticsPsychologistLifecycle[];
   requestRows: TherapyRequestAnalyticsLifecycleRow[];
   requestRowsTotal: number;
   unlinkedSessionCount: number;
   noSessionRequestCount: number;
+  scoringModel: {
+    supportedWeights: Record<TherapyRequestAnalyticsMetricKey, number>;
+    excludedMetrics: Array<{
+      metric: 'documentation';
+      reason: string;
+    }>;
+    metricDescriptors: Record<
+      TherapyRequestAnalyticsMetricDescriptorKey,
+      TherapyRequestAnalyticsMetricDescriptor
+    >;
+    confidenceThresholdClients: number;
+    period: {
+      startDate?: string;
+      endDate?: string;
+      month?: string;
+      timezone: 'UTC';
+    };
+  };
 }
 
 export interface AnalyticsFieldInferenceValue {

--- a/src/therapy-sessions/schemas/therapy-session.schema.ts
+++ b/src/therapy-sessions/schemas/therapy-session.schema.ts
@@ -43,6 +43,7 @@ export const therapySessionSchema =
 
 therapySessionSchema.index({ psychologist: 1, dateTime: 1 });
 therapySessionSchema.index({ psychologist: 1, client: 1 });
-therapySessionSchema.index({ therapyRequest: 1 });
+// KPI lifecycle aggregation uses $firstN, so production MongoDB must be 5.2+.
+therapySessionSchema.index({ therapyRequest: 1, dateTime: 1, _id: 1 });
 therapySessionSchema.index({ dateTime: 1 });
 therapySessionSchema.index({ client: 1 });


### PR DESCRIPTION
Lifecycle days told you nothing. Who starts clients? Who keeps them? NOBODY KNEW. Now: one weighted score — retention, start rate, time to first session, regularity. Confidence levels. Warnings. A full audit trail in the xlsx.

Long overdue!

BREAKING CHANGE: `GET /therapy-request-analytics/lifecycle` keeps its route but returns a new KPI payload — `shortestPsychologists`/`longestPsychologists` are replaced by `topPsychologists`/`bottomPsychologists` carrying `baseScore`, per-metric breakdowns, and `confidenceLevel`, plus new `insufficientDataPsychologists` and `scoringModel`; row-level `lifecycleDays` is removed in favor of `firstTenSessionCount`/`firstTenMedianIntervalDays`. The endpoint now always filters to accepted requests, ignoring the `accepted` query param. XLSX sheets and columns are renamed. Requires MongoDB 5.2+ (`$firstN`) and replaces the therapy-session index with `{therapyRequest, dateTime, _id}`.