### PR TITLE
feat: LINKS in notifications — VALIDATED!

### DIFF
--- a/src/notifications/dto/create-notification.dto.ts
+++ b/src/notifications/dto/create-notification.dto.ts
@@ -1,12 +1,14 @@
 import { Role } from '@/roles/enums/roles.enum';
 import { NotificationStatuses } from '../enums/notification-statuses.enum';
 import { NotificationTypes } from '../enums/notification-types.enum';
+import { NotificationMessageEntity } from '../types/notification-message-entity';
 
 export class CreateNotificationDto {
   type: NotificationTypes;
   status?: NotificationStatuses;
   title?: string;
   message?: string;
+  messageEntities?: Array<NotificationMessageEntity>;
   roles?: Array<Role>;
   recipients?: Array<string>;
   startsAt?: string;

--- a/src/notifications/dto/update-notification.dto.ts
+++ b/src/notifications/dto/update-notification.dto.ts
@@ -1,11 +1,13 @@
 import { Role } from '@/roles/enums/roles.enum';
 import { NotificationStatuses } from '../enums/notification-statuses.enum';
+import { NotificationMessageEntity } from '../types/notification-message-entity';
 
 export class UpdateNotificationDto {
   roles?: Array<Role>;
   recipients?: Array<string>;
   title?: string;
   message?: string;
+  messageEntities?: Array<NotificationMessageEntity>;
   received?: Array<string>;
   status?: NotificationStatuses;
   startsAt?: string;

--- a/src/notifications/notifications.service.spec.ts
+++ b/src/notifications/notifications.service.spec.ts
@@ -1,14 +1,25 @@
 import { getModelToken } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from '../users/users.service';
+import { NotificationTypes } from './enums/notification-types.enum';
 import { NotificationsService } from './notifications.service';
 import { Notification } from './schemas/notification.schema';
+import { joiCreateNotificationSchema } from './schemas/joi.create-notification.schema';
 
 describe('NotificationsService', () => {
   let service: NotificationsService;
+  let mockNotificationModel: {
+    find: jest.Mock;
+    findById: jest.Mock;
+    create: jest.Mock;
+    findByIdAndUpdate: jest.Mock;
+    findOneAndUpdate: jest.Mock;
+    findOne: jest.Mock;
+    findByIdAndRemove: jest.Mock;
+  };
 
   beforeEach(async () => {
-    const mockNotificationModel = {
+    mockNotificationModel = {
       find: jest.fn(),
       findById: jest.fn(),
       create: jest.fn(),
@@ -41,5 +52,94 @@ describe('NotificationsService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('message entity validation', () => {
+    it('accepts valid notification message entities', () => {
+      const result = joiCreateNotificationSchema.validate({
+        type: NotificationTypes.MESSAGE,
+        message: 'Text link',
+        messageEntities: [
+          {
+            type: 'text_link',
+            offset: 5,
+            length: 4,
+            url: 'https://example.com',
+          },
+        ],
+      });
+
+      expect(result.error).toBeUndefined();
+    });
+
+    it('rejects invalid urls and out-of-range entities', () => {
+      const invalidUrl = joiCreateNotificationSchema.validate({
+        type: NotificationTypes.MESSAGE,
+        message: 'Text link',
+        messageEntities: [
+          {
+            type: 'text_link',
+            offset: 5,
+            length: 4,
+            url: 'javascript:alert(1)',
+          },
+        ],
+      });
+      const invalidRange = joiCreateNotificationSchema.validate({
+        type: NotificationTypes.MESSAGE,
+        message: 'Text link',
+        messageEntities: [
+          {
+            type: 'text_link',
+            offset: 5,
+            length: 99,
+            url: 'https://example.com',
+          },
+        ],
+      });
+
+      expect(invalidUrl.error).toBeDefined();
+      expect(invalidRange.error).toBeDefined();
+    });
+
+    it('rejects too many entities and entities without message', () => {
+      const tooManyEntities = joiCreateNotificationSchema.validate({
+        type: NotificationTypes.MESSAGE,
+        message: 'Text link',
+        messageEntities: Array.from({ length: 51 }, () => ({
+          type: 'url',
+          offset: 0,
+          length: 4,
+        })),
+      });
+      const withoutMessage = joiCreateNotificationSchema.validate({
+        type: NotificationTypes.MESSAGE,
+        messageEntities: [
+          {
+            type: 'url',
+            offset: 0,
+            length: 4,
+          },
+        ],
+      });
+
+      expect(tooManyEntities.error).toBeDefined();
+      expect(withoutMessage.error).toBeDefined();
+    });
+  });
+
+  it('clears stale message entities on message-only updates', async () => {
+    const exec = jest.fn().mockResolvedValue({});
+    mockNotificationModel.findByIdAndUpdate.mockReturnValue({ exec });
+
+    await service.update('notification-id', { message: 'Updated text' });
+
+    expect(mockNotificationModel.findByIdAndUpdate).toHaveBeenCalledWith(
+      'notification-id',
+      expect.objectContaining({
+        message: 'Updated text',
+        messageEntities: [],
+      }),
+    );
   });
 });

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -148,18 +148,26 @@ export class NotificationsService {
     const validationResult = joiUpdateNotificationSchema.validate(updateData);
 
     if (!validationResult.error) {
+      const updatePayload = { ...validationResult.value };
+      if (
+        Object.prototype.hasOwnProperty.call(updatePayload, 'message') &&
+        !Object.prototype.hasOwnProperty.call(updatePayload, 'messageEntities')
+      ) {
+        updatePayload.messageEntities = [];
+      }
+
       const recipients: Array<mongoose.Types.ObjectId> | undefined =
-        updateData.recipients
-          ? updateData.recipients.map(valueToObjectId)
+        updatePayload.recipients
+          ? updatePayload.recipients.map(valueToObjectId)
           : undefined;
 
       const received: Array<mongoose.Types.ObjectId> | undefined =
-        updateData.received
-          ? updateData.received.map(valueToObjectId)
+        updatePayload.received
+          ? updatePayload.received.map(valueToObjectId)
           : undefined;
 
       return this.notificationModel
-        .findByIdAndUpdate(id, { ...updateData, recipients, received })
+        .findByIdAndUpdate(id, { ...updatePayload, recipients, received })
         .exec();
     }
 

--- a/src/notifications/schemas/joi.create-notification.schema.ts
+++ b/src/notifications/schemas/joi.create-notification.schema.ts
@@ -3,6 +3,7 @@ import { Role } from '@/roles/enums/roles.enum';
 import { CreateNotificationDto } from '../dto/create-notification.dto';
 import { NotificationStatuses } from '../enums/notification-statuses.enum';
 import { NotificationTypes } from '../enums/notification-types.enum';
+import { joiNotificationMessageEntitiesSchema } from './joi.notification-message-entity.schema';
 
 export const joiCreateNotificationSchema = Joi.object<CreateNotificationDto>({
   type: Joi.string()
@@ -11,8 +12,9 @@ export const joiCreateNotificationSchema = Joi.object<CreateNotificationDto>({
   status: Joi.string().valid(...Object.values(NotificationStatuses)),
   title: Joi.string(),
   message: Joi.string(),
+  messageEntities: joiNotificationMessageEntitiesSchema,
   roles: Joi.array<Role>().items(...Object.values(Role)),
   recipients: Joi.array<string>(),
   startsAt: Joi.date().iso(),
   finishAt: Joi.date().iso(),
-});
+}).with('messageEntities', 'message');

--- a/src/notifications/schemas/joi.notification-message-entity.schema.ts
+++ b/src/notifications/schemas/joi.notification-message-entity.schema.ts
@@ -1,0 +1,44 @@
+import * as Joi from 'joi';
+import { NotificationMessageEntity } from '../types/notification-message-entity';
+
+const MAX_NOTIFICATION_MESSAGE_ENTITIES = 50;
+
+const joiNotificationMessageEntitySchema =
+  Joi.alternatives<NotificationMessageEntity>().try(
+    Joi.object({
+      type: Joi.string().valid('url').required(),
+      offset: Joi.number().integer().min(0).required(),
+      length: Joi.number().integer().min(1).required(),
+    }),
+    Joi.object({
+      type: Joi.string().valid('text_link').required(),
+      offset: Joi.number().integer().min(0).required(),
+      length: Joi.number().integer().min(1).required(),
+      url: Joi.string()
+        .uri({ scheme: ['http', 'https'] })
+        .required(),
+    }),
+  );
+
+function validateMessageEntityBounds(
+  entities: Array<NotificationMessageEntity>,
+  helpers: Joi.CustomHelpers,
+) {
+  const root = helpers.state.ancestors[0] as { message?: string } | undefined;
+  const message = root?.message || '';
+
+  if (
+    entities.some((entity) => entity.offset + entity.length > message.length)
+  ) {
+    return helpers.error('any.invalid');
+  }
+
+  return entities;
+}
+
+export const joiNotificationMessageEntitiesSchema = Joi.array<
+  Array<NotificationMessageEntity>
+>()
+  .max(MAX_NOTIFICATION_MESSAGE_ENTITIES)
+  .items(joiNotificationMessageEntitySchema)
+  .custom(validateMessageEntityBounds, 'message entity bounds validation');

--- a/src/notifications/schemas/joi.update-notification.schema.ts
+++ b/src/notifications/schemas/joi.update-notification.schema.ts
@@ -2,6 +2,7 @@ import * as Joi from 'joi';
 import { Role } from '@/roles/enums/roles.enum';
 import { UpdateNotificationDto } from '../dto/update-notification.dto';
 import { NotificationStatuses } from '../enums/notification-statuses.enum';
+import { joiNotificationMessageEntitiesSchema } from './joi.notification-message-entity.schema';
 
 export const joiUpdateNotificationSchema = Joi.object<UpdateNotificationDto>({
   status: Joi.array<NotificationStatuses>().items(
@@ -10,8 +11,9 @@ export const joiUpdateNotificationSchema = Joi.object<UpdateNotificationDto>({
   roles: Joi.array<Role>().items(...Object.values(Role)),
   title: Joi.string(),
   message: Joi.string(),
+  messageEntities: joiNotificationMessageEntitiesSchema,
   recipients: Joi.array<string>(),
   received: Joi.array<string>(),
   startsAt: Joi.date().iso(),
   finishAt: Joi.date().iso(),
-});
+}).with('messageEntities', 'message');

--- a/src/notifications/schemas/notification.schema.ts
+++ b/src/notifications/schemas/notification.schema.ts
@@ -4,6 +4,7 @@ import { Role } from '@/roles/enums/roles.enum';
 import { UserDocument } from '@/users/schemas/user.schema';
 import { NotificationStatuses } from '../enums/notification-statuses.enum';
 import { NotificationTypes } from '../enums/notification-types.enum';
+import { NotificationMessageEntity } from '../types/notification-message-entity';
 
 export type NotificationDocument = Notification &
   Document & { createdAt: Date; updatedAt: Date };
@@ -21,6 +22,21 @@ export class Notification {
 
   @Prop({ required: false, default: '' })
   message: string;
+
+  @Prop({
+    required: false,
+    type: [
+      {
+        _id: false,
+        type: { type: String, required: true },
+        offset: { type: Number, required: true },
+        length: { type: Number, required: true },
+        url: { type: String, required: false },
+      },
+    ],
+    default: [],
+  })
+  messageEntities: Array<NotificationMessageEntity>;
 
   @Prop({ required: true, default: [] })
   roles: Array<Role>;

--- a/src/notifications/types/notification-message-entity.ts
+++ b/src/notifications/types/notification-message-entity.ts
@@ -1,0 +1,13 @@
+export type NotificationMessageEntity =
+  | {
+      type: 'url';
+      offset: number;
+      length: number;
+    }
+  | {
+      type: 'text_link';
+      offset: number;
+      length: number;
+      url: string;
+    };
+


### PR DESCRIPTION
Notifications were plain text. Flat. Boring. No links allowed. Now messageEntities ride along — url and text_link spans, bounds-checked, https-only, capped at 50. Stale spans get wiped when the message changes.

Nobody validates entities like this. NOBODY!