### PR TITLE
fix: addReceived — ATOMIC. ONE CLAIM ONLY!

### DIFF
--- a/src/notifications/notifications.service.spec.ts
+++ b/src/notifications/notifications.service.spec.ts
@@ -17,6 +17,9 @@ describe('NotificationsService', () => {
     findOne: jest.Mock;
     findByIdAndRemove: jest.Mock;
   };
+  let mockUsersService: {
+    getById: jest.Mock;
+  };
 
   beforeEach(async () => {
     mockNotificationModel = {
@@ -29,7 +32,7 @@ describe('NotificationsService', () => {
       findByIdAndRemove: jest.fn(),
     };
 
-    const mockUsersService = {
+    mockUsersService = {
       getById: jest.fn(),
     };
 
@@ -141,5 +144,64 @@ describe('NotificationsService', () => {
         messageEntities: [],
       }),
     );
+  });
+
+  describe('addReceived', () => {
+    it('returns true only when the call claims a new received user', async () => {
+      const exec = jest.fn().mockResolvedValue({ _id: 'notification-id' });
+      const updateStatusSpy = jest
+        .spyOn(service, 'updateNotificationStatus')
+        .mockResolvedValue(undefined);
+      mockUsersService.getById.mockResolvedValue({ _id: 'user-id' });
+      mockNotificationModel.findOneAndUpdate.mockReturnValue({ exec });
+
+      await expect(
+        service.addReceived('notification-id', 'user-id'),
+      ).resolves.toBe(true);
+
+      expect(mockNotificationModel.findOneAndUpdate).toHaveBeenCalledWith(
+        {
+          _id: 'notification-id',
+          received: {
+            $not: { $elemMatch: { $eq: 'user-id' } },
+          },
+        },
+        {
+          $addToSet: { received: 'user-id' },
+        },
+      );
+      expect(updateStatusSpy).toHaveBeenCalledWith('notification-id');
+      expect(mockNotificationModel.findOne).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the user was already received', async () => {
+      const exec = jest.fn().mockResolvedValue(null);
+      const updateStatusSpy = jest
+        .spyOn(service, 'updateNotificationStatus')
+        .mockResolvedValue(undefined);
+      mockUsersService.getById.mockResolvedValue({ _id: 'user-id' });
+      mockNotificationModel.findOneAndUpdate.mockReturnValue({ exec });
+
+      await expect(
+        service.addReceived('notification-id', 'user-id'),
+      ).resolves.toBe(false);
+
+      expect(updateStatusSpy).not.toHaveBeenCalled();
+      expect(mockNotificationModel.findOne).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the user cannot be found', async () => {
+      const updateStatusSpy = jest
+        .spyOn(service, 'updateNotificationStatus')
+        .mockResolvedValue(undefined);
+      mockUsersService.getById.mockResolvedValue(null);
+
+      await expect(
+        service.addReceived('notification-id', 'missing-user-id'),
+      ).resolves.toBe(false);
+
+      expect(mockNotificationModel.findOneAndUpdate).not.toHaveBeenCalled();
+      expect(updateStatusSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -179,7 +179,7 @@ export class NotificationsService {
     if (!user) return false;
 
     // NOTICE: add user to received list in notification
-    await this.notificationModel
+    const updatedNotification = await this.notificationModel
       .findOneAndUpdate(
         {
           _id: notificationId,
@@ -193,19 +193,13 @@ export class NotificationsService {
       )
       .exec();
 
+    if (!updatedNotification) {
+      return false;
+    }
+
     await this.updateNotificationStatus(notificationId);
 
-    // NOTICE: check if user was added to received list in notification
-    return (
-      (await this.notificationModel
-        .findOne({
-          _id: notificationId,
-          received: {
-            $elemMatch: { $eq: user._id },
-          },
-        })
-        .count()) === 1
-    );
+    return true;
   }
 
   async updateNotificationStatus(notificationId: string) {


### PR DESCRIPTION
Two queries to answer one question. Racy. Duplicates slipped through. Now findOneAndUpdate claims the receipt in one shot — already received means false, no second lookup.

Fast. Atomic. CORRECT!