### PR TITLE
feat: analytics OVER TIME — DAY, WEEK, MONTH, YEAR!

### DIFF
--- a/src/therapy-requests/schemas/joi.therapy-request-analytics-query.schema.ts
+++ b/src/therapy-requests/schemas/joi.therapy-request-analytics-query.schema.ts
@@ -1,0 +1,39 @@
+import * as Joi from 'joi';
+import { joiObjectId } from '@/common/schemas/joi.object-id.schema';
+import {
+  TherapyRequestCategory,
+  TherapyRequestClientGender,
+} from '../enums/therapy-request-analytics.enum';
+import type { AnalyticsGranularity } from '../types/therapy-request-analytics.types';
+
+const analyticsGranularities: AnalyticsGranularity[] = [
+  'day',
+  'week',
+  'month',
+  'year',
+];
+
+export const therapyRequestAnalyticsQuerySchema = Joi.object({
+  month: Joi.string()
+    .pattern(/^\d{4}-\d{2}$/)
+    .optional(),
+  startDate: Joi.date().iso().optional(),
+  endDate: Joi.date().iso().optional(),
+  granularity: Joi.string()
+    .valid(...analyticsGranularities)
+    .default('week'),
+  clientGender: Joi.string()
+    .valid(...Object.values(TherapyRequestClientGender))
+    .optional(),
+  requestCategory: Joi.string()
+    .valid(...Object.values(TherapyRequestCategory))
+    .optional(),
+  psychologist: joiObjectId.optional(),
+  accepted: Joi.boolean().truthy('true').falsy('false').optional(),
+  analyticsReviewRequired: Joi.boolean()
+    .truthy('true')
+    .falsy('false')
+    .optional(),
+  limit: Joi.number().integer().min(1).max(1000).optional(),
+  offset: Joi.number().integer().min(0).optional(),
+});

--- a/src/therapy-requests/therapy-request-analytics.controller.ts
+++ b/src/therapy-requests/therapy-request-analytics.controller.ts
@@ -6,6 +6,7 @@ import { Roles } from '@/roles/decorators/role.docorator';
 import { Role } from '@/roles/enums/roles.enum';
 import { UserDocument } from '@/users/schemas/user.schema';
 import { UpdateTherapyRequestAnalyticsDto } from './dto/update-therapy-request-analytics.dto';
+import { therapyRequestAnalyticsQuerySchema } from './schemas/joi.therapy-request-analytics-query.schema';
 import { joiUpdateTherapyRequestAnalyticsSchema } from './schemas/joi.update-therapy-request-analytics.schema';
 import { TherapyRequestAnalyticsService } from './therapy-request-analytics.service';
 import { TherapyRequestsService } from './therapy-requests.service';
@@ -35,7 +36,8 @@ export class TherapyRequestAnalyticsController {
   @Get('summary')
   @Roles(Role.Admin, Role.Editor)
   getSummary(
-    @Query() query: TherapyRequestAnalyticsQuery,
+    @Query(new JoiValidationPipe(therapyRequestAnalyticsQuerySchema))
+    query: TherapyRequestAnalyticsQuery,
   ): Promise<TherapyRequestAnalyticsSummaryResponse> {
     return this.analyticsService.getSummary(query);
   }

--- a/src/therapy-requests/therapy-request-analytics.service.spec.ts
+++ b/src/therapy-requests/therapy-request-analytics.service.spec.ts
@@ -4,7 +4,7 @@ import {
   buildSessionCountPipeline,
   buildSessionDatePipeline,
 } from './therapy-request-analytics.service';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import mongoose from 'mongoose';
 
 function chain(result: unknown) {
@@ -188,6 +188,467 @@ describe('TherapyRequestAnalyticsService', () => {
         },
       ],
     });
+    expect(result.weekly.period.groupingTimezone).toBe('UTC');
+    expect(result.weekly.applications).toHaveLength(52);
+    expect(result.weekly.applications).toHaveLength(
+      result.weekly.sessions.length,
+    );
+    expect(result.timeSeries.granularity).toBe('week');
+    expect(result.timeSeries.applications[0].bucketStart).toBe(
+      result.weekly.applications[0].weekStart,
+    );
+  });
+
+  it('rejects unsupported summary granularities', async () => {
+    const service = new TherapyRequestAnalyticsService(
+      {
+        aggregate: jest.fn().mockReturnValue(aggregateChain([{}])),
+        distinct: jest.fn(),
+        collection: { name: 'therapyrequests' },
+      } as any,
+      {
+        aggregate: jest.fn().mockReturnValue(aggregateChain([])),
+        countDocuments: jest.fn().mockReturnValue(countChain(0)),
+        collection: { name: 'therapysessions' },
+      } as any,
+      { find: jest.fn() } as any,
+    );
+
+    await expect(
+      service.getSummary({ granularity: 'quarter' }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('returns ordered zero-filled weekly applications and sessions for a selected month', async () => {
+    const requestAggregate = jest
+      .fn()
+      .mockReturnValueOnce(
+        aggregateChain([
+          {
+            total: [{ total: 3 }],
+            reviewRequired: [],
+            monthlyTotals: [],
+            monthlyCategories: [],
+            monthlyGenders: [],
+            categoryBreakdown: [],
+            genderBreakdown: [],
+          },
+        ]),
+      )
+      .mockReturnValueOnce(
+        aggregateChain([
+          {
+            _id: '2025-12-29',
+            total: 2,
+            withSessions: 1,
+            withoutSessions: 1,
+          },
+          {
+            _id: '2026-01-05',
+            total: 1,
+            withSessions: 1,
+            withoutSessions: 0,
+          },
+        ]),
+      );
+    const sessionAggregate = jest.fn().mockReturnValue(
+      aggregateChain([
+        { _id: '2025-12-29', total: 1 },
+        { _id: '2026-01-05', total: 2 },
+      ]),
+    );
+    const service = new TherapyRequestAnalyticsService(
+      {
+        aggregate: requestAggregate,
+        distinct: jest.fn(),
+        collection: { name: 'therapyrequests' },
+      } as any,
+      {
+        aggregate: sessionAggregate,
+        countDocuments: jest.fn().mockReturnValue(countChain(0)),
+        collection: { name: 'therapysessions' },
+      } as any,
+      { find: jest.fn() } as any,
+    );
+
+    const result = await service.getSummary({ month: '2026-01' });
+
+    expect(result.weekly.period).toEqual({
+      groupingTimezone: 'UTC',
+      weekStartsOn: 'monday',
+      effectiveStartDate: '2026-01-01',
+      effectiveEndDate: '2026-01-31',
+      source: 'month',
+    });
+    expect(result.timeSeries).toMatchObject({
+      granularity: 'week',
+      period: {
+        groupingTimezone: 'UTC',
+        effectiveStartDate: '2026-01-01',
+        effectiveEndDate: '2026-01-31',
+        source: 'month',
+      },
+    });
+    expect(result.weekly.applications.map((row) => row.weekStart)).toEqual([
+      '2025-12-29',
+      '2026-01-05',
+      '2026-01-12',
+      '2026-01-19',
+      '2026-01-26',
+    ]);
+    expect(result.weekly.sessions.map((row) => row.weekStart)).toEqual(
+      result.weekly.applications.map((row) => row.weekStart),
+    );
+    expect(
+      result.timeSeries.applications.map((row) => row.bucketStart),
+    ).toEqual(result.weekly.applications.map((row) => row.weekStart));
+    expect(result.timeSeries.sessions.map((row) => row.bucketStart)).toEqual(
+      result.weekly.sessions.map((row) => row.weekStart),
+    );
+    expect(result.weekly.applications[0]).toEqual({
+      weekStart: '2025-12-29',
+      total: 2,
+      withSessions: 1,
+      withoutSessions: 1,
+    });
+    expect(result.weekly.applications[1]).toEqual({
+      weekStart: '2026-01-05',
+      total: 1,
+      withSessions: 1,
+      withoutSessions: 0,
+    });
+    expect(
+      result.weekly.applications.every(
+        (row) => row.total === row.withSessions + row.withoutSessions,
+      ),
+    ).toBe(true);
+    expect(result.weekly.sessions[1]).toEqual({
+      weekStart: '2026-01-05',
+      total: 2,
+    });
+    expect(result.weekly.sessions[2]).toEqual({
+      weekStart: '2026-01-12',
+      total: 0,
+    });
+  });
+
+  it('returns ordered zero-filled daily applications and sessions for a selected month', async () => {
+    const requestAggregate = jest
+      .fn()
+      .mockReturnValueOnce(aggregateChain([{}]))
+      .mockReturnValueOnce(
+        aggregateChain([
+          {
+            _id: '2026-02-01',
+            total: 2,
+            withSessions: 1,
+            withoutSessions: 1,
+          },
+          {
+            _id: '2026-02-29',
+            total: 1,
+            withSessions: 0,
+            withoutSessions: 1,
+          },
+        ]),
+      );
+    const sessionAggregate = jest
+      .fn()
+      .mockReturnValue(aggregateChain([{ _id: '2026-02-28', total: 3 }]));
+    const service = new TherapyRequestAnalyticsService(
+      {
+        aggregate: requestAggregate,
+        distinct: jest.fn(),
+        collection: { name: 'therapyrequests' },
+      } as any,
+      {
+        aggregate: sessionAggregate,
+        countDocuments: jest.fn().mockReturnValue(countChain(0)),
+        collection: { name: 'therapysessions' },
+      } as any,
+      { find: jest.fn() } as any,
+    );
+
+    const result = await service.getSummary({
+      month: '2026-02',
+      granularity: 'day',
+    });
+
+    expect(result.weekly).toBeUndefined();
+    expect(result.timeSeries.granularity).toBe('day');
+    expect(result.timeSeries.period).toEqual({
+      groupingTimezone: 'UTC',
+      effectiveStartDate: '2026-02-01',
+      effectiveEndDate: '2026-02-28',
+      source: 'month',
+    });
+    expect(result.timeSeries.applications).toHaveLength(28);
+    expect(result.timeSeries.applications[0]).toEqual({
+      bucketStart: '2026-02-01',
+      total: 2,
+      withSessions: 1,
+      withoutSessions: 1,
+    });
+    expect(result.timeSeries.applications[27]).toEqual({
+      bucketStart: '2026-02-28',
+      total: 0,
+      withSessions: 0,
+      withoutSessions: 0,
+    });
+    expect(result.timeSeries.sessions[27]).toEqual({
+      bucketStart: '2026-02-28',
+      total: 3,
+    });
+
+    const applicationPipeline = requestAggregate.mock.calls[1][0];
+    expect(applicationPipeline).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          $addFields: expect.objectContaining({
+            _bucketStart: expect.objectContaining({
+              $dateToString: expect.objectContaining({
+                date: expect.objectContaining({
+                  $dateTrunc: expect.objectContaining({ unit: 'day' }),
+                }),
+              }),
+            }),
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it('caps explicit time-series date ranges to the default 52-week span', async () => {
+    const requestAggregate = jest
+      .fn()
+      .mockReturnValueOnce(aggregateChain([{}]))
+      .mockReturnValueOnce(aggregateChain([]));
+    const sessionAggregate = jest.fn().mockReturnValue(aggregateChain([]));
+    const service = new TherapyRequestAnalyticsService(
+      {
+        aggregate: requestAggregate,
+        distinct: jest.fn(),
+        collection: { name: 'therapyrequests' },
+      } as any,
+      {
+        aggregate: sessionAggregate,
+        countDocuments: jest.fn().mockReturnValue(countChain(0)),
+        collection: { name: 'therapysessions' },
+      } as any,
+      { find: jest.fn() } as any,
+    );
+
+    const result = await service.getSummary({
+      startDate: '2020-01-01',
+      endDate: '2026-08-07',
+      granularity: 'day',
+    });
+
+    expect(result.timeSeries.period).toEqual({
+      groupingTimezone: 'UTC',
+      effectiveStartDate: '2020-01-01',
+      effectiveEndDate: '2020-12-29',
+      source: 'range',
+    });
+    expect(result.timeSeries.applications).toHaveLength(364);
+    expect(result.timeSeries.sessions).toHaveLength(364);
+    expect(result.timeSeries.applications[0].bucketStart).toBe('2020-01-01');
+    expect(result.timeSeries.applications[363].bucketStart).toBe('2020-12-29');
+
+    expect(requestAggregate.mock.calls[1][0][0].$match.createdAt).toEqual({
+      $gte: new Date('2020-01-01T00:00:00.000Z'),
+      $lt: new Date('2020-12-30T00:00:00.000Z'),
+    });
+    expect(sessionAggregate.mock.calls[0][0][0].$match.dateTime).toEqual({
+      $gte: new Date('2020-01-01T00:00:00.000Z').getTime(),
+      $lt: new Date('2020-12-30T00:00:00.000Z').getTime(),
+    });
+  });
+
+  it('returns month and year buckets without local-time date shifts', async () => {
+    const service = new TherapyRequestAnalyticsService(
+      {
+        aggregate: jest
+          .fn()
+          .mockReturnValueOnce(aggregateChain([{}]))
+          .mockReturnValueOnce(aggregateChain([]))
+          .mockReturnValueOnce(aggregateChain([{}]))
+          .mockReturnValueOnce(aggregateChain([])),
+        distinct: jest.fn(),
+        collection: { name: 'therapyrequests' },
+      } as any,
+      {
+        aggregate: jest.fn().mockReturnValue(aggregateChain([])),
+        countDocuments: jest.fn().mockReturnValue(countChain(0)),
+        collection: { name: 'therapysessions' },
+      } as any,
+      { find: jest.fn() } as any,
+    );
+
+    const monthly = await service.getSummary({
+      startDate: '2026-01-15',
+      endDate: '2026-03-02',
+      granularity: 'month',
+    });
+    const yearly = await service.getSummary({
+      startDate: '2025-12-31',
+      endDate: '2026-01-01',
+      granularity: 'year',
+    });
+
+    expect(
+      monthly.timeSeries.applications.map((row) => row.bucketStart),
+    ).toEqual(['2026-01-01', '2026-02-01', '2026-03-01']);
+    expect(
+      yearly.timeSeries.applications.map((row) => row.bucketStart),
+    ).toEqual(['2025-01-01', '2026-01-01']);
+  });
+
+  it('uses latest 52 Monday week keys for default weekly analytics', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-06T12:00:00Z'));
+    const service = new TherapyRequestAnalyticsService(
+      {
+        aggregate: jest
+          .fn()
+          .mockReturnValueOnce(aggregateChain([{}]))
+          .mockReturnValueOnce(aggregateChain([])),
+        distinct: jest.fn(),
+        collection: { name: 'therapyrequests' },
+      } as any,
+      {
+        aggregate: jest.fn().mockReturnValue(aggregateChain([])),
+        countDocuments: jest.fn().mockReturnValue(countChain(0)),
+        collection: { name: 'therapysessions' },
+      } as any,
+      { find: jest.fn() } as any,
+    );
+
+    try {
+      const result = await service.getSummary({});
+
+      expect(result.weekly.period).toMatchObject({
+        effectiveStartDate: '2025-08-11',
+        effectiveEndDate: '2026-08-09',
+        source: 'default',
+      });
+      expect(result.weekly.applications).toHaveLength(52);
+      expect(result.weekly.applications[0].weekStart).toBe('2025-08-11');
+      expect(result.weekly.applications[51].weekStart).toBe('2026-08-03');
+      expect(result.weekly.sessions.map((row) => row.weekStart)).toEqual(
+        result.weekly.applications.map((row) => row.weekStart),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('applies request dates only to weekly applications and non-date request filters to weekly sessions', async () => {
+    const requestAggregate = jest
+      .fn()
+      .mockReturnValueOnce(aggregateChain([{}]))
+      .mockReturnValueOnce(aggregateChain([]));
+    const sessionAggregate = jest.fn().mockReturnValue(aggregateChain([]));
+    const service = new TherapyRequestAnalyticsService(
+      {
+        aggregate: requestAggregate,
+        distinct: jest.fn(),
+        collection: { name: 'therapyrequests' },
+      } as any,
+      {
+        aggregate: sessionAggregate,
+        countDocuments: jest.fn().mockReturnValue(countChain(0)),
+        collection: { name: 'therapysessions' },
+      } as any,
+      { find: jest.fn() } as any,
+    );
+
+    await service.getSummary({
+      startDate: '2026-01-07',
+      endDate: '2026-01-20',
+      clientGender: 'female',
+      accepted: 'true',
+    });
+
+    const applicationPipeline = requestAggregate.mock.calls[1][0];
+    expect(applicationPipeline[0]).toEqual({
+      $match: {
+        clientGender: 'female',
+        accepted: true,
+        createdAt: {
+          $gte: new Date('2026-01-07T00:00:00.000Z'),
+          $lt: new Date('2026-01-21T00:00:00.000Z'),
+        },
+      },
+    });
+    expect(applicationPipeline).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          $lookup: expect.objectContaining({
+            from: 'therapysessions',
+            pipeline: expect.arrayContaining([{ $limit: 1 }]),
+          }),
+        }),
+      ]),
+    );
+
+    const sessionPipeline = sessionAggregate.mock.calls[0][0];
+    expect(sessionPipeline[0]).toEqual({
+      $match: {
+        therapyRequest: { $exists: true, $ne: null },
+        dateTime: {
+          $gte: new Date('2026-01-07T00:00:00.000Z').getTime(),
+          $lt: new Date('2026-01-21T00:00:00.000Z').getTime(),
+        },
+      },
+    });
+    expect(sessionPipeline).toEqual(
+      expect.arrayContaining([
+        { $match: { $expr: buildFiniteSessionDateExpression() } },
+      ]),
+    );
+    expect(sessionPipeline[2].$lookup.pipeline).toEqual([
+      {
+        $match: {
+          $expr: { $eq: ['$_id', '$$requestId'] },
+        },
+      },
+      { $match: { clientGender: 'female', accepted: true } },
+      { $project: { _id: 1 } },
+    ]);
+  });
+
+  it('bounds open weekly ranges with the current UTC date or 52 weeks from the provided side', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-06T12:00:00Z'));
+    const service = new TherapyRequestAnalyticsService(
+      {
+        aggregate: jest
+          .fn()
+          .mockReturnValueOnce(aggregateChain([{}]))
+          .mockReturnValueOnce(aggregateChain([])),
+        distinct: jest.fn(),
+        collection: { name: 'therapyrequests' },
+      } as any,
+      {
+        aggregate: jest.fn().mockReturnValue(aggregateChain([])),
+        countDocuments: jest.fn().mockReturnValue(countChain(0)),
+        collection: { name: 'therapysessions' },
+      } as any,
+      { find: jest.fn() } as any,
+    );
+
+    try {
+      const result = await service.getSummary({ startDate: '2026-01-07' });
+
+      expect(result.weekly.period).toMatchObject({
+        effectiveStartDate: '2026-01-07',
+        effectiveEndDate: '2026-08-06',
+        source: 'range',
+      });
+      expect(result.weekly.applications[0].weekStart).toBe('2026-01-05');
+      expect(result.weekly.applications.at(-1)?.weekStart).toBe('2026-08-03');
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('returns paginated request-level list responses with projected fields', async () => {

--- a/src/therapy-requests/therapy-request-analytics.service.ts
+++ b/src/therapy-requests/therapy-request-analytics.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { FilterQuery, Model, Types } from 'mongoose';
 import ExcelJS from 'exceljs';
@@ -21,6 +25,7 @@ import {
 } from './schemas/therapy-request.schema';
 import {
   PaginatedResponse,
+  AnalyticsGranularity,
   TherapyRequestAnalyticsMetricBreakdown,
   TherapyRequestAnalyticsMetricKey,
   TherapyRequestAnalyticsFiltersResponse,
@@ -31,12 +36,17 @@ import {
   TherapyRequestAnalyticsRequest,
   TherapyRequestAnalyticsRequestsResponse,
   TherapyRequestAnalyticsSummaryResponse,
+  TherapyRequestAnalyticsTimeSeriesSummary,
+  TherapyRequestAnalyticsWeeklySummary,
   TherapyRequestAnalyticsWarningKey,
 } from './types/therapy-request-analytics.types';
 
 const dayMs = 1000 * 60 * 60 * 24;
 const DEFAULT_REQUEST_LIMIT = 20;
 const MAX_REQUEST_LIMIT = 1000;
+const DEFAULT_WEEK_COUNT = 52;
+const DEFAULT_TIME_SERIES_DAYS = DEFAULT_WEEK_COUNT * 7;
+const MAX_TIME_SERIES_RANGE_DAYS = DEFAULT_TIME_SERIES_DAYS;
 const CONFIDENCE_THRESHOLD_CLIENTS = 5;
 const DOCUMENTATION_UNAVAILABLE_REASON =
   'No independent source for completed sessions exists; recorded session rows are the only evidence a session happened.';
@@ -200,6 +210,40 @@ function monthKey(date: Date): string {
   )}`;
 }
 
+function calendarDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function addUtcDays(date: Date, days: number): Date {
+  return new Date(date.getTime() + days * dayMs);
+}
+
+function utcDayStart(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+}
+
+function utcMondayStart(date: Date): Date {
+  const start = utcDayStart(date);
+  const day = start.getUTCDay();
+  const offset = day === 0 ? -6 : 1 - day;
+  return addUtcDays(start, offset);
+}
+
+function parseUtcDate(value?: string): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  return utcDayStart(date);
+}
+
 function normalizeGender(value?: string): TherapyRequestClientGender {
   return Object.values(TherapyRequestClientGender).includes(
     value as TherapyRequestClientGender,
@@ -266,6 +310,19 @@ type DateRangeFilter = {
   $lte?: Date;
   $lt?: Date;
 };
+
+type TimeSeriesPeriod = {
+  start: Date;
+  endExclusive: Date;
+  effectiveStartDate: string;
+  effectiveEndDate: string;
+  source: TherapyRequestAnalyticsTimeSeriesSummary['period']['source'];
+};
+
+type SummaryWithoutWeekly = Omit<
+  TherapyRequestAnalyticsSummaryResponse,
+  'timeSeries' | 'weekly'
+>;
 
 type ProjectedTherapyRequest = TherapyRequestAnalyticsRequest;
 
@@ -411,68 +468,79 @@ export class TherapyRequestAnalyticsService {
   async getSummary(
     query: TherapyRequestAnalyticsQuery,
   ): Promise<TherapyRequestAnalyticsSummaryResponse> {
-    const [result] = await this.therapyRequestModel
-      .aggregate([
-        { $match: this.buildRequestFilter(query) },
-        {
-          $addFields: {
-            _clientGender: {
-              $ifNull: ['$clientGender', TherapyRequestClientGender.Unknown],
+    const granularity = this.parseGranularity(query.granularity);
+    const [summaryRows, timeSeries] = await Promise.all([
+      this.therapyRequestModel
+        .aggregate([
+          { $match: this.buildRequestFilter(query) },
+          {
+            $addFields: {
+              _clientGender: {
+                $ifNull: ['$clientGender', TherapyRequestClientGender.Unknown],
+              },
+              _requestCategory: {
+                $ifNull: ['$requestCategory', TherapyRequestCategory.Unknown],
+              },
+              _analyticsReviewRequired: {
+                $cond: [
+                  { $eq: ['$analyticsReviewRequired', false] },
+                  false,
+                  true,
+                ],
+              },
+              _month: {
+                $dateToString: { format: '%Y-%m', date: '$createdAt' },
+              },
             },
-            _requestCategory: {
-              $ifNull: ['$requestCategory', TherapyRequestCategory.Unknown],
-            },
-            _analyticsReviewRequired: {
-              $cond: [
-                { $eq: ['$analyticsReviewRequired', false] },
-                false,
-                true,
+          },
+          {
+            $facet: {
+              total: [{ $count: 'total' }],
+              reviewRequired: [
+                { $match: { _analyticsReviewRequired: true } },
+                { $count: 'total' },
+              ],
+              monthlyTotals: [
+                { $group: { _id: '$_month', total: { $sum: 1 } } },
+                { $sort: { _id: 1 } },
+              ],
+              monthlyCategories: [
+                {
+                  $group: {
+                    _id: { month: '$_month', category: '$_requestCategory' },
+                    total: { $sum: 1 },
+                  },
+                },
+              ],
+              monthlyGenders: [
+                {
+                  $group: {
+                    _id: { month: '$_month', gender: '$_clientGender' },
+                    total: { $sum: 1 },
+                  },
+                },
+              ],
+              categoryBreakdown: [
+                { $group: { _id: '$_requestCategory', total: { $sum: 1 } } },
+              ],
+              genderBreakdown: [
+                { $group: { _id: '$_clientGender', total: { $sum: 1 } } },
               ],
             },
-            _month: {
-              $dateToString: { format: '%Y-%m', date: '$createdAt' },
-            },
           },
-        },
-        {
-          $facet: {
-            total: [{ $count: 'total' }],
-            reviewRequired: [
-              { $match: { _analyticsReviewRequired: true } },
-              { $count: 'total' },
-            ],
-            monthlyTotals: [
-              { $group: { _id: '$_month', total: { $sum: 1 } } },
-              { $sort: { _id: 1 } },
-            ],
-            monthlyCategories: [
-              {
-                $group: {
-                  _id: { month: '$_month', category: '$_requestCategory' },
-                  total: { $sum: 1 },
-                },
-              },
-            ],
-            monthlyGenders: [
-              {
-                $group: {
-                  _id: { month: '$_month', gender: '$_clientGender' },
-                  total: { $sum: 1 },
-                },
-              },
-            ],
-            categoryBreakdown: [
-              { $group: { _id: '$_requestCategory', total: { $sum: 1 } } },
-            ],
-            genderBreakdown: [
-              { $group: { _id: '$_clientGender', total: { $sum: 1 } } },
-            ],
-          },
-        },
-      ])
-      .exec();
+        ])
+        .exec(),
+      this.buildTimeSeriesSummary(query, granularity),
+    ]);
+    const [result] = summaryRows;
 
-    return this.buildSummaryFromAggregation(result);
+    return {
+      ...this.buildSummaryFromAggregation(result),
+      timeSeries,
+      ...(granularity === 'week'
+        ? { weekly: this.buildWeeklyCompatibility(timeSeries) }
+        : {}),
+    };
   }
 
   async getLifecycle(
@@ -1185,6 +1253,367 @@ export class TherapyRequestAnalyticsService {
       .exec() as Promise<ProjectedTherapyRequest[]>;
   }
 
+  private parseGranularity(value: unknown): AnalyticsGranularity {
+    if (!value) {
+      return 'week';
+    }
+
+    if (
+      value === 'day' ||
+      value === 'week' ||
+      value === 'month' ||
+      value === 'year'
+    ) {
+      return value;
+    }
+
+    throw new BadRequestException('Unsupported analytics granularity');
+  }
+
+  private async buildTimeSeriesSummary(
+    query: TherapyRequestAnalyticsQuery,
+    granularity: AnalyticsGranularity,
+  ): Promise<TherapyRequestAnalyticsTimeSeriesSummary> {
+    const period = this.deriveTimeSeriesPeriod(query);
+    const bucketKeys = this.enumerateBucketKeys(period, granularity);
+    const [applicationRows, sessionRows] = await Promise.all([
+      this.aggregateTimeSeriesApplications(query, period, granularity),
+      this.aggregateTimeSeriesSessions(query, period, granularity),
+    ]);
+
+    return {
+      granularity,
+      applications: this.mergeTimeSeriesApplications(
+        bucketKeys,
+        applicationRows,
+      ),
+      sessions: this.mergeTimeSeriesSessions(bucketKeys, sessionRows),
+      period: {
+        groupingTimezone: 'UTC',
+        effectiveStartDate: period.effectiveStartDate,
+        effectiveEndDate: period.effectiveEndDate,
+        source: period.source,
+      },
+    };
+  }
+
+  private buildWeeklyCompatibility(
+    timeSeries: TherapyRequestAnalyticsTimeSeriesSummary,
+  ): TherapyRequestAnalyticsWeeklySummary {
+    return {
+      applications: timeSeries.applications.map((point) => ({
+        weekStart: point.bucketStart,
+        total: point.total,
+        withSessions: point.withSessions,
+        withoutSessions: point.withoutSessions,
+      })),
+      sessions: timeSeries.sessions.map((point) => ({
+        weekStart: point.bucketStart,
+        total: point.total,
+      })),
+      period: {
+        groupingTimezone: 'UTC',
+        weekStartsOn: 'monday',
+        effectiveStartDate: timeSeries.period.effectiveStartDate,
+        effectiveEndDate: timeSeries.period.effectiveEndDate,
+        source: timeSeries.period.source,
+      },
+    };
+  }
+
+  private deriveTimeSeriesPeriod(
+    query: TherapyRequestAnalyticsQuery,
+  ): TimeSeriesPeriod {
+    if (query.month && /^\d{4}-\d{2}$/.test(query.month)) {
+      const [year, month] = query.month.split('-').map(Number);
+      const start = new Date(Date.UTC(year, month - 1, 1));
+      const endExclusive = new Date(Date.UTC(year, month, 1));
+      return {
+        start,
+        endExclusive,
+        effectiveStartDate: calendarDateKey(start),
+        effectiveEndDate: calendarDateKey(addUtcDays(endExclusive, -1)),
+        source: 'month',
+      };
+    }
+
+    const explicitStart = parseUtcDate(query.startDate);
+    const explicitEnd = parseUtcDate(query.endDate);
+    if (explicitStart || explicitEnd) {
+      const currentUtcDay = utcDayStart(new Date());
+      const start = explicitStart
+        ? explicitStart
+        : addUtcDays(explicitEnd as Date, -(MAX_TIME_SERIES_RANGE_DAYS - 1));
+      const maxEnd = addUtcDays(start, MAX_TIME_SERIES_RANGE_DAYS - 1);
+      const requestedEnd = explicitEnd
+        ? explicitEnd
+        : new Date(Math.min(currentUtcDay.getTime(), maxEnd.getTime()));
+      const end = new Date(Math.min(requestedEnd.getTime(), maxEnd.getTime()));
+      const endExclusive = addUtcDays(end, 1);
+
+      return {
+        start,
+        endExclusive,
+        effectiveStartDate: calendarDateKey(start),
+        effectiveEndDate: calendarDateKey(addUtcDays(endExclusive, -1)),
+        source: 'range',
+      };
+    }
+
+    const currentWeekStart = utcMondayStart(new Date());
+    const start = addUtcDays(currentWeekStart, -(DEFAULT_WEEK_COUNT - 1) * 7);
+    const endExclusive = addUtcDays(currentWeekStart, 7);
+    return {
+      start,
+      endExclusive,
+      effectiveStartDate: calendarDateKey(start),
+      effectiveEndDate: calendarDateKey(addUtcDays(endExclusive, -1)),
+      source: 'default',
+    };
+  }
+
+  private bucketStart(date: Date, granularity: AnalyticsGranularity): Date {
+    if (granularity === 'week') {
+      return utcMondayStart(date);
+    }
+
+    if (granularity === 'month') {
+      return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+    }
+
+    if (granularity === 'year') {
+      return new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+    }
+
+    return utcDayStart(date);
+  }
+
+  private addBucket(date: Date, granularity: AnalyticsGranularity): Date {
+    if (granularity === 'week') {
+      return addUtcDays(date, 7);
+    }
+
+    if (granularity === 'month') {
+      return new Date(
+        Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 1),
+      );
+    }
+
+    if (granularity === 'year') {
+      return new Date(Date.UTC(date.getUTCFullYear() + 1, 0, 1));
+    }
+
+    return addUtcDays(date, 1);
+  }
+
+  private enumerateBucketKeys(
+    period: TimeSeriesPeriod,
+    granularity: AnalyticsGranularity,
+  ): string[] {
+    if (period.endExclusive <= period.start) {
+      return [];
+    }
+
+    const keys: string[] = [];
+    const lastBucketStart = this.bucketStart(
+      addUtcDays(period.endExclusive, -1),
+      granularity,
+    );
+    for (
+      let cursor = this.bucketStart(period.start, granularity);
+      cursor <= lastBucketStart;
+      cursor = this.addBucket(cursor, granularity)
+    ) {
+      keys.push(calendarDateKey(cursor));
+    }
+
+    return keys;
+  }
+
+  private getTherapyRequestCollectionName(): string {
+    return this.therapyRequestModel.collection?.name || 'therapyrequests';
+  }
+
+  private getTherapySessionCollectionName(): string {
+    return this.therapySessionModel.collection?.name || 'therapysessions';
+  }
+
+  private bucketDateExpression(
+    dateExpression: unknown,
+    granularity: AnalyticsGranularity,
+  ) {
+    const unit = granularity === 'week' ? 'week' : granularity;
+
+    return {
+      $dateToString: {
+        format: '%Y-%m-%d',
+        timezone: 'UTC',
+        date: {
+          $dateTrunc: {
+            date: dateExpression,
+            unit,
+            timezone: 'UTC',
+            ...(granularity === 'week' ? { startOfWeek: 'monday' } : {}),
+          },
+        },
+      },
+    };
+  }
+
+  private async aggregateTimeSeriesApplications(
+    query: TherapyRequestAnalyticsQuery,
+    period: TimeSeriesPeriod,
+    granularity: AnalyticsGranularity,
+  ): Promise<
+    Array<{
+      _id: string;
+      total: number;
+      withSessions: number;
+      withoutSessions: number;
+    }>
+  > {
+    const requestFilter = {
+      ...this.buildRequestFilter(query, { includeDateFilters: false }),
+      createdAt: {
+        $gte: period.start,
+        $lt: period.endExclusive,
+      },
+    };
+
+    return this.therapyRequestModel
+      .aggregate([
+        { $match: requestFilter },
+        {
+          $lookup: {
+            from: this.getTherapySessionCollectionName(),
+            let: { requestId: '$_id' },
+            pipeline: [
+              {
+                $match: {
+                  $expr: { $eq: ['$therapyRequest', '$$requestId'] },
+                },
+              },
+              { $limit: 1 },
+              { $project: { _id: 1 } },
+            ],
+            as: '_linkedSession',
+          },
+        },
+        {
+          $addFields: {
+            _bucketStart: this.bucketDateExpression('$createdAt', granularity),
+            _hasLinkedSession: { $gt: [{ $size: '$_linkedSession' }, 0] },
+          },
+        },
+        {
+          $group: {
+            _id: '$_bucketStart',
+            total: { $sum: 1 },
+            withSessions: {
+              $sum: { $cond: ['$_hasLinkedSession', 1, 0] },
+            },
+            withoutSessions: {
+              $sum: { $cond: ['$_hasLinkedSession', 0, 1] },
+            },
+          },
+        },
+        { $sort: { _id: 1 } },
+      ])
+      .exec();
+  }
+
+  private async aggregateTimeSeriesSessions(
+    query: TherapyRequestAnalyticsQuery,
+    period: TimeSeriesPeriod,
+    granularity: AnalyticsGranularity,
+  ): Promise<Array<{ _id: string; total: number }>> {
+    const requestFilter = this.buildRequestFilter(query, {
+      includeDateFilters: false,
+    });
+
+    return this.therapySessionModel
+      .aggregate([
+        {
+          $match: {
+            therapyRequest: { $exists: true, $ne: null },
+            dateTime: {
+              $gte: period.start.getTime(),
+              $lt: period.endExclusive.getTime(),
+            },
+          },
+        },
+        { $match: { $expr: buildFiniteSessionDateExpression() } },
+        {
+          $lookup: {
+            from: this.getTherapyRequestCollectionName(),
+            let: { requestId: '$therapyRequest' },
+            pipeline: [
+              {
+                $match: {
+                  $expr: { $eq: ['$_id', '$$requestId'] },
+                },
+              },
+              { $match: requestFilter },
+              { $project: { _id: 1 } },
+            ],
+            as: '_request',
+          },
+        },
+        { $match: { '_request.0': { $exists: true } } },
+        {
+          $addFields: {
+            _bucketStart: this.bucketDateExpression(
+              { $toDate: '$dateTime' },
+              granularity,
+            ),
+          },
+        },
+        {
+          $group: {
+            _id: '$_bucketStart',
+            total: { $sum: 1 },
+          },
+        },
+        { $sort: { _id: 1 } },
+      ])
+      .exec();
+  }
+
+  private mergeTimeSeriesApplications(
+    bucketKeys: string[],
+    rows: Array<{
+      _id: string;
+      total?: number;
+      withSessions?: number;
+    }>,
+  ): TherapyRequestAnalyticsTimeSeriesSummary['applications'] {
+    const rowsByBucket = new Map(rows.map((row) => [row._id, row]));
+
+    return bucketKeys.map((bucketStart) => {
+      const row = rowsByBucket.get(bucketStart);
+      const total = row?.total || 0;
+      const withSessions = row?.withSessions || 0;
+      return {
+        bucketStart,
+        total,
+        withSessions,
+        withoutSessions: Math.max(0, total - withSessions),
+      };
+    });
+  }
+
+  private mergeTimeSeriesSessions(
+    bucketKeys: string[],
+    rows: Array<{ _id: string; total?: number }>,
+  ): TherapyRequestAnalyticsTimeSeriesSummary['sessions'] {
+    const rowsByBucket = new Map(rows.map((row) => [row._id, row]));
+
+    return bucketKeys.map((bucketStart) => ({
+      bucketStart,
+      total: rowsByBucket.get(bucketStart)?.total || 0,
+    }));
+  }
+
   private buildSummaryFromAggregation(result?: {
     total?: Array<{ total: number }>;
     reviewRequired?: Array<{ total: number }>;
@@ -1199,7 +1628,7 @@ export class TherapyRequestAnalyticsService {
     }>;
     categoryBreakdown?: Array<{ _id: string; total: number }>;
     genderBreakdown?: Array<{ _id: string; total: number }>;
-  }): TherapyRequestAnalyticsSummaryResponse {
+  }): SummaryWithoutWeekly {
     const monthlyMap = new Map<
       string,
       {
@@ -1272,7 +1701,7 @@ export class TherapyRequestAnalyticsService {
 
   private buildSummaryFromRequests(
     requests: SummaryInputRequest[],
-  ): TherapyRequestAnalyticsSummaryResponse {
+  ): SummaryWithoutWeekly {
     const monthlyMap = new Map<
       string,
       {
@@ -1332,12 +1761,15 @@ export class TherapyRequestAnalyticsService {
 
   private buildRequestFilter(
     query: TherapyRequestAnalyticsQuery,
+    options: { includeDateFilters?: boolean } = { includeDateFilters: true },
   ): FilterQuery<TherapyRequestDocument> {
     const filter: FilterQuery<TherapyRequestDocument> = {};
 
-    const dateRange = this.parseDateRange(query);
-    if (dateRange) {
-      filter.createdAt = dateRange;
+    if (options.includeDateFilters !== false) {
+      const dateRange = this.parseDateRange(query);
+      if (dateRange) {
+        filter.createdAt = dateRange;
+      }
     }
 
     if (

--- a/src/therapy-requests/types/therapy-request-analytics.types.ts
+++ b/src/therapy-requests/types/therapy-request-analytics.types.ts
@@ -7,6 +7,7 @@ export interface TherapyRequestAnalyticsQuery {
   month?: string;
   startDate?: string;
   endDate?: string;
+  granularity?: AnalyticsGranularity | string;
   clientGender?: TherapyRequestClientGender | string;
   requestCategory?: TherapyRequestCategory | string;
   psychologist?: string;
@@ -80,6 +81,58 @@ export interface TherapyRequestAnalyticsSummaryResponse {
     gender: TherapyRequestClientGender;
     total: number;
   }>;
+  timeSeries: TherapyRequestAnalyticsTimeSeriesSummary;
+  weekly?: TherapyRequestAnalyticsWeeklySummary;
+}
+
+export type AnalyticsGranularity = 'day' | 'week' | 'month' | 'year';
+
+export interface TherapyRequestAnalyticsTimeSeriesSummary {
+  granularity: AnalyticsGranularity;
+  applications: TherapyRequestAnalyticsTimeSeriesApplicationsPoint[];
+  sessions: TherapyRequestAnalyticsTimeSeriesSessionsPoint[];
+  period: {
+    groupingTimezone: 'UTC';
+    effectiveStartDate: string;
+    effectiveEndDate: string;
+    source: 'month' | 'range' | 'default';
+  };
+}
+
+export interface TherapyRequestAnalyticsTimeSeriesApplicationsPoint {
+  bucketStart: string;
+  total: number;
+  withSessions: number;
+  withoutSessions: number;
+}
+
+export interface TherapyRequestAnalyticsTimeSeriesSessionsPoint {
+  bucketStart: string;
+  total: number;
+}
+
+export interface TherapyRequestAnalyticsWeeklySummary {
+  applications: TherapyRequestAnalyticsWeeklyApplicationsPoint[];
+  sessions: TherapyRequestAnalyticsWeeklySessionsPoint[];
+  period: {
+    groupingTimezone: 'UTC';
+    weekStartsOn: 'monday';
+    effectiveStartDate: string;
+    effectiveEndDate: string;
+    source: 'month' | 'range' | 'default';
+  };
+}
+
+export interface TherapyRequestAnalyticsWeeklyApplicationsPoint {
+  weekStart: string;
+  total: number;
+  withSessions: number;
+  withoutSessions: number;
+}
+
+export interface TherapyRequestAnalyticsWeeklySessionsPoint {
+  weekStart: string;
+  total: number;
 }
 
 export interface TherapyRequestAnalyticsLifecycleRow {


### PR DESCRIPTION
The summary gave you totals. Flat numbers. No sense of trend at all. Now it returns time series — applications split by with-sessions and without, sessions counted per bucket, any granularity you pick. The query gets validated too. Weekly stays for compatibility.

The best analytics endpoint in history!

BREAKING CHANGE: GET /therapy-request-analytics/summary now validates its query strictly (400 on unknown params or bad values) and always returns a `timeSeries` object; `weekly` is included only for week granularity.