### PR TITLE
feat: FULL psychologist list — NOBODY dropped!

### DIFF
--- a/docs/ADMIN-API-EXAMPLES.md
+++ b/docs/ADMIN-API-EXAMPLES.md
@@ -2504,6 +2504,7 @@ Response:
 
 Admin/editor. Returns KPI-based psychologist rankings and request-level audit rows. The route name is kept for compatibility.
 The KPI session aggregation uses MongoDB `$firstN`; production MongoDB must be 5.2+.
+Newer responses include additive `allPsychologists` with every specialist produced by the KPI aggregation, including `insufficient_data` rows. Legacy `topPsychologists`, `bottomPsychologists`, and `insufficientDataPsychologists` remain for independent deployment compatibility; older API responses may omit `allPsychologists`.
 
 Response:
 

--- a/docs/ADMIN-WEB-API.md
+++ b/docs/ADMIN-WEB-API.md
@@ -1142,7 +1142,9 @@ KPI analytics (`GET /therapy-request-analytics/lifecycle`):
 - Supported score weights are retention `36.84%`, start rate `26.32%`, time to first session `21.05%`, and regularity `15.79%`.
 - Documentation score is unavailable and excluded because there is no independent source for completed sessions; recorded session rows are the only evidence a session happened.
 - Confidence is informational only: `min(clientsWithAtLeastOneSession / 5, 1)`. Low confidence does not change score, ranking, or eligibility.
-- Specialists missing any supported metric get `baseScore: null`, `scoreStatus: "insufficient_data"`, and are returned outside Top 10 / Bottom 10.
+- `allPsychologists` contains every specialist produced by the KPI aggregation, including scored and `insufficient_data` rows. Legacy `topPsychologists`, `bottomPsychologists`, and `insufficientDataPsychologists` remain for compatibility.
+- Specialists missing any supported metric get `baseScore: null`, `scoreStatus: "insufficient_data"`, and are included in `allPsychologists` and `insufficientDataPsychologists`.
+- `dom-web` and `dom-api` deploy independently; frontend versions that support `allPsychologists` must keep the legacy Top/Bottom UI when this field is absent from an older API response.
 - No archived/deleted/cancelled/duplicate/test request status exists in the current schema, so those categories are not silently filtered.
 
 Export returns an `.xlsx` file respecting current filters. Sheets: raw requests, monthly summary, category breakdown, psychologist KPI scores, and KPI request audit.

--- a/src/therapy-requests/therapy-request-analytics.service.spec.ts
+++ b/src/therapy-requests/therapy-request-analytics.service.spec.ts
@@ -5,6 +5,7 @@ import {
   buildSessionDatePipeline,
 } from './therapy-request-analytics.service';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
+import ExcelJS from 'exceljs';
 import mongoose from 'mongoose';
 
 function chain(result: unknown) {
@@ -937,6 +938,7 @@ describe('TherapyRequestAnalyticsService', () => {
     });
 
     expect(result.topPsychologists).toHaveLength(1);
+    expect(result.allPsychologists).toEqual(result.topPsychologists);
     expect(result.bottomPsychologists).toEqual([]);
     expect(result.topPsychologists[0]).toMatchObject({
       psychologistName: 'Dr One',
@@ -998,6 +1000,65 @@ describe('TherapyRequestAnalyticsService', () => {
       .reduce((sum, contribution) => sum + contribution, 0);
     expect(result.topPsychologists[0].baseScore).toBe(
       Math.round(contributionTotal * 10) / 10,
+    );
+  });
+
+  it('returns all scored psychologists without top and bottom truncation', async () => {
+    const requests = Array.from({ length: 12 }, (_, index) => {
+      const ordinal = String(index + 1).padStart(2, '0');
+
+      return {
+        _id: id(`request-${ordinal}`),
+        createdAt: new Date(`2026-01-${ordinal}T00:00:00Z`),
+        name: `Client ${ordinal}`,
+        psychologist: {
+          _id: id(`psychologist-${ordinal}`),
+          user: { name: `Dr ${ordinal}` },
+        },
+      };
+    });
+    const sessionCountRows = requests.map((request) => ({
+      _id: request._id,
+      linkedSessionCount: 2,
+      invalidSessionDateCount: 0,
+    }));
+    const sessionDateRows = requests.map((request, index) => {
+      const day = String(index + 1).padStart(2, '0');
+
+      return {
+        _id: request._id,
+        firstSessionAt: new Date(`2026-02-${day}T00:00:00Z`).getTime(),
+        latestSessionAt: new Date(`2026-02-${day}T00:00:00Z`).getTime(),
+        firstTenSessionDates: [
+          new Date(`2026-02-${day}T00:00:00Z`).getTime(),
+          new Date(`2026-02-${day}T00:00:00Z`).getTime(),
+        ],
+      };
+    });
+    const service = new TherapyRequestAnalyticsService(
+      {
+        find: jest.fn().mockReturnValue(chain(requests)),
+        aggregate: jest.fn().mockReturnValue(aggregateChain([])),
+        distinct: jest.fn(),
+      } as any,
+      {
+        aggregate: jest
+          .fn()
+          .mockReturnValueOnce(aggregateChain(sessionCountRows))
+          .mockReturnValueOnce(aggregateChain(sessionDateRows)),
+        countDocuments: jest.fn().mockReturnValue(countChain(0)),
+      } as any,
+      { find: jest.fn() } as any,
+    );
+
+    const result = await service.getLifecycle({});
+
+    expect(result.topPsychologists).toHaveLength(10);
+    expect(result.bottomPsychologists).toHaveLength(2);
+    expect(result.insufficientDataPsychologists).toHaveLength(0);
+    expect(result.allPsychologists).toHaveLength(12);
+    expect(result.allPsychologists.map((row) => row.psychologistName)).toEqual(
+      requests.map((request) => request.psychologist.user.name),
     );
   });
 
@@ -1282,6 +1343,13 @@ describe('TherapyRequestAnalyticsService', () => {
 
     expect(result.requestRowsTotal).toBe(3);
     expect(result.topPsychologists).toHaveLength(0);
+    expect(result.allPsychologists).toEqual([
+      expect.objectContaining({
+        psychologistName: 'Dr One',
+        baseScore: null,
+        missingMetrics: ['timeToFirstSession', 'regularity'],
+      }),
+    ]);
     expect(result.insufficientDataPsychologists).toEqual([
       expect.objectContaining({
         psychologistName: 'Dr One',
@@ -1296,8 +1364,46 @@ describe('TherapyRequestAnalyticsService', () => {
     ]);
   });
 
-  it('exports an xlsx workbook buffer from a single request fetch', async () => {
-    const find = jest.fn().mockReturnValue(chain([]));
+  it('exports an xlsx workbook buffer with every KPI psychologist row', async () => {
+    const requests = Array.from({ length: 21 }, (_, index) => {
+      const ordinal = String(index + 1).padStart(2, '0');
+
+      return {
+        _id: id(`request-${ordinal}`),
+        createdAt: new Date(`2026-01-${ordinal}T00:00:00Z`),
+        updatedAt: new Date(`2026-01-${ordinal}T00:00:00Z`),
+        name: `Client ${ordinal}`,
+        descr: `Description ${ordinal}`,
+        accepted: true,
+        clientGender: 'unknown',
+        requestCategory: 'individual',
+        analyticsReviewRequired: false,
+        analyticsInference: {},
+        psychologist: {
+          _id: id(`psychologist-${ordinal}`),
+          user: { name: `Dr ${ordinal}` },
+        },
+      };
+    });
+    const sessionCountRows = requests.map((request) => ({
+      _id: request._id,
+      linkedSessionCount: 2,
+      invalidSessionDateCount: 0,
+    }));
+    const sessionDateRows = requests.map((request, index) => {
+      const day = String(index + 1).padStart(2, '0');
+
+      return {
+        _id: request._id,
+        firstSessionAt: new Date(`2026-02-${day}T00:00:00Z`).getTime(),
+        latestSessionAt: new Date(`2026-02-${day}T00:00:00Z`).getTime(),
+        firstTenSessionDates: [
+          new Date(`2026-02-${day}T00:00:00Z`).getTime(),
+          new Date(`2026-02-${day}T00:00:00Z`).getTime(),
+        ],
+      };
+    });
+    const find = jest.fn().mockReturnValue(chain(requests));
     const service = new TherapyRequestAnalyticsService(
       {
         find,
@@ -1305,7 +1411,10 @@ describe('TherapyRequestAnalyticsService', () => {
         distinct: jest.fn(),
       } as any,
       {
-        aggregate: jest.fn().mockReturnValue(aggregateChain([])),
+        aggregate: jest
+          .fn()
+          .mockReturnValueOnce(aggregateChain(sessionCountRows))
+          .mockReturnValueOnce(aggregateChain(sessionDateRows)),
         countDocuments: jest.fn().mockReturnValue(countChain(0)),
       } as any,
       { find: jest.fn() } as any,
@@ -1316,5 +1425,28 @@ describe('TherapyRequestAnalyticsService', () => {
     expect(Buffer.isBuffer(buffer)).toBe(true);
     expect(buffer.subarray(0, 2).toString()).toBe('PK');
     expect(find).toHaveBeenCalledTimes(2);
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(buffer);
+    const psychologistSheet = workbook.getWorksheet('Psychologist KPI scores');
+    expect(psychologistSheet).toBeDefined();
+    const psychologistRows: Array<{
+      group: ExcelJS.CellValue;
+      psychologistName: ExcelJS.CellValue;
+    }> = [];
+    psychologistSheet?.eachRow((row, rowNumber) => {
+      if (rowNumber === 1) {
+        return;
+      }
+
+      psychologistRows.push({
+        group: row.getCell(1).value,
+        psychologistName: row.getCell(2).value,
+      });
+    });
+    expect(psychologistRows).toContainEqual({
+      group: 'scored',
+      psychologistName: 'Dr 11',
+    });
+    expect(psychologistRows).toHaveLength(21);
   });
 });

--- a/src/therapy-requests/therapy-request-analytics.service.ts
+++ b/src/therapy-requests/therapy-request-analytics.service.ts
@@ -679,6 +679,12 @@ export class TherapyRequestAnalyticsService {
     const scoredSpecialists = specialists.filter(
       (row) => row.scoreStatus === 'scored' && row.baseScore !== null,
     );
+    const sortedScoredSpecialists = [...scoredSpecialists].sort((a, b) =>
+      this.sortScoredSpecialists(a, b, 'desc'),
+    );
+    const insufficientDataPsychologists = specialists
+      .filter((row) => row.scoreStatus === 'insufficient_data')
+      .sort((a, b) => this.sortSpecialistsByName(a, b));
 
     const unlinkedSessionCount = await this.countUnlinkedSessions(query);
     const requestRowsTotal = requestRows.length;
@@ -692,9 +698,7 @@ export class TherapyRequestAnalyticsService {
       options.paginateRows === false
         ? requestRows
         : requestRows.slice(rowOffset, rowOffset + rowLimit);
-    const topPsychologists = [...scoredSpecialists]
-      .sort((a, b) => this.sortScoredSpecialists(a, b, 'desc'))
-      .slice(0, 10);
+    const topPsychologists = sortedScoredSpecialists.slice(0, 10);
     const bottomPsychologists =
       scoredSpecialists.length > 10
         ? [...scoredSpecialists]
@@ -709,11 +713,13 @@ export class TherapyRequestAnalyticsService {
         : [];
 
     return {
+      allPsychologists: [
+        ...sortedScoredSpecialists,
+        ...insufficientDataPsychologists,
+      ],
       topPsychologists,
       bottomPsychologists,
-      insufficientDataPsychologists: specialists
-        .filter((row) => row.scoreStatus === 'insufficient_data')
-        .sort((a, b) => this.sortSpecialistsByName(a, b)),
+      insufficientDataPsychologists,
       requestRows: paginatedRequestRows,
       requestRowsTotal,
       unlinkedSessionCount,
@@ -1152,12 +1158,8 @@ export class TherapyRequestAnalyticsService {
         missingMetrics: row.missingMetrics.join(', '),
         warnings: row.warnings.join(', '),
       });
-    lifecycle.topPsychologists.forEach((row) => addPsychologistRow('top', row));
-    lifecycle.bottomPsychologists.forEach((row) =>
-      addPsychologistRow('bottom', row),
-    );
-    lifecycle.insufficientDataPsychologists.forEach((row) =>
-      addPsychologistRow('insufficient_data', row),
+    lifecycle.allPsychologists.forEach((row) =>
+      addPsychologistRow(row.scoreStatus, row),
     );
 
     const requestLifecycleSheet = workbook.addWorksheet('KPI request audit');

--- a/src/therapy-requests/types/therapy-request-analytics.types.ts
+++ b/src/therapy-requests/types/therapy-request-analytics.types.ts
@@ -207,8 +207,24 @@ export interface TherapyRequestAnalyticsPsychologistLifecycle {
 }
 
 export interface TherapyRequestAnalyticsLifecycleResponse {
+  allPsychologists: TherapyRequestAnalyticsPsychologistLifecycle[];
+  /**
+   * @deprecated Compatibility field for deploy skew. Remove after one
+   * production release where dom-api emits allPsychologists and deployed
+   * dom-web no longer needs the legacy Top/Bottom fallback.
+   */
   topPsychologists: TherapyRequestAnalyticsPsychologistLifecycle[];
+  /**
+   * @deprecated Compatibility field for deploy skew. Remove after one
+   * production release where dom-api emits allPsychologists and deployed
+   * dom-web no longer needs the legacy Top/Bottom fallback.
+   */
   bottomPsychologists: TherapyRequestAnalyticsPsychologistLifecycle[];
+  /**
+   * @deprecated Compatibility field for deploy skew. Remove after one
+   * production release where dom-api emits allPsychologists and deployed
+   * dom-web no longer needs the legacy Top/Bottom fallback.
+   */
   insufficientDataPsychologists: TherapyRequestAnalyticsPsychologistLifecycle[];
   requestRows: TherapyRequestAnalyticsLifecycleRow[];
   requestRowsTotal: number;


### PR DESCRIPTION
Top 10, bottom 10, and the middle? Gone from the export. Rank 11 vanished. Some got counted twice. A MESS. New allPsychologists field carries every specialist, scored then insufficient. The xlsx walks that one list now — no gaps, no duplicates.

Everybody counts. HANDLED!