### PR TITLE
feat: batch notifications — ACK, not GUESSWORK!

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ npm run audit:auth-passwords
 - `auth-by-token` - Authenticate WebSocket connection
 - `notifications/get-my` - Get user notifications
 - `notifications/get-all` - Get all active notifications (API clients)
+- `notifications/get-all-batch` - Get all active notifications as ACK payload (API clients)
 - `notifications/add-received` - Mark notification as received
 
 ## 🧪 Testing

--- a/src/ws/ws.gateway.spec.ts
+++ b/src/ws/ws.gateway.spec.ts
@@ -1,22 +1,35 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { WsGateway } from './ws.gateway';
+import { Observable } from 'rxjs';
 import { AuthService } from '../auth/auth.service';
 import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationDocument } from '../notifications/schemas/notification.schema';
+import { WsGateway } from './ws.gateway';
 
 describe('WsGateway', () => {
   let gateway: WsGateway;
+  let mockAuthService: {
+    verifyToken: jest.Mock;
+    isAvailableClient: jest.Mock;
+    decode: jest.Mock;
+  };
+  let mockNotificationsService: {
+    getAllActive: jest.Mock;
+    getAllByUserId: jest.Mock;
+    addReceived: jest.Mock;
+  };
+  let connectionHandler: (client: unknown) => Promise<void>;
 
   beforeEach(async () => {
-    const mockAuthService = {
-      validateApiClient: jest.fn(),
-      validateTokenAndGetUser: jest.fn(),
+    mockAuthService = {
+      verifyToken: jest.fn(),
+      isAvailableClient: jest.fn(),
+      decode: jest.fn(),
     };
 
-    const mockNotificationsService = {
-      getAll: jest.fn(),
+    mockNotificationsService = {
+      getAllActive: jest.fn(),
       getAllByUserId: jest.fn(),
-      create: jest.fn(),
-      markAsReceived: jest.fn(),
+      addReceived: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -34,9 +47,97 @@ describe('WsGateway', () => {
     }).compile();
 
     gateway = module.get<WsGateway>(WsGateway);
+    gateway.server = {
+      on: jest.fn((_event, handler) => {
+        connectionHandler = handler;
+      }),
+    } as never;
+    gateway.onModuleInit();
   });
 
   it('should be defined', () => {
     expect(gateway).toBeDefined();
   });
+
+  it('returns active notifications through the ACK batch event for API clients', async () => {
+    const notifications = [{ _id: 'notification-1' }];
+    const client = createClient(
+      'batch-authorized',
+      `ApiClient ${JSON.stringify({ name: 'bot', password: 'secret' })}`,
+    );
+
+    mockAuthService.isAvailableClient.mockReturnValue(true);
+    mockNotificationsService.getAllActive.mockResolvedValue(notifications);
+
+    await connectionHandler(client);
+
+    await expect(gateway.getAllActiveEventsBatch(client as never)).resolves.toBe(
+      notifications,
+    );
+    expect(mockNotificationsService.getAllActive).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the same active notification source for the streamed event', async () => {
+    const notifications = [
+      { _id: 'notification-1' },
+      { _id: 'notification-2' },
+    ];
+    const client = createClient(
+      'stream-authorized',
+      `ApiClient ${JSON.stringify({ name: 'bot', password: 'secret' })}`,
+    );
+
+    mockAuthService.isAvailableClient.mockReturnValue(true);
+    mockNotificationsService.getAllActive.mockResolvedValue(notifications);
+
+    await connectionHandler(client);
+
+    const result = await gateway.getAllActiveEvents(client as never);
+
+    await expect(collectObservable(result)).resolves.toEqual([
+      { event: 'notification', data: notifications[0] },
+      { event: 'notification', data: notifications[1] },
+    ]);
+    expect(mockNotificationsService.getAllActive).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves empty unauthorized behavior for batch and streamed events', async () => {
+    const client = createClient('unauthorized');
+
+    await connectionHandler(client);
+
+    await expect(gateway.getAllActiveEventsBatch(client as never)).resolves.toEqual(
+      [],
+    );
+
+    const result = await gateway.getAllActiveEvents(client as never);
+    await expect(collectObservable(result)).resolves.toEqual([]);
+    expect(mockNotificationsService.getAllActive).not.toHaveBeenCalled();
+  });
 });
+
+function createClient(id: string, authorization?: string) {
+  return {
+    id,
+    handshake: {
+      headers: authorization ? { authorization } : {},
+    },
+    emit: jest.fn(),
+  };
+}
+
+function collectObservable(
+  observable: Observable<{
+    event: string;
+    data: NotificationDocument;
+  }>,
+): Promise<Array<{ event: string; data: NotificationDocument }>> {
+  return new Promise((resolve, reject) => {
+    const values: Array<{ event: string; data: NotificationDocument }> = [];
+    observable.subscribe({
+      next: (value) => values.push(value),
+      error: reject,
+      complete: () => resolve(values),
+    });
+  });
+}

--- a/src/ws/ws.gateway.ts
+++ b/src/ws/ws.gateway.ts
@@ -104,16 +104,18 @@ export class WsGateway implements OnModuleInit {
   async getAllActiveEvents(
     @ConnectedSocket() client: Socket,
   ): Promise<Observable<WsResponse<NotificationDocument>> | never> {
-    const apiClient = socketToApiClient[client.id];
-
-    let notifications: Array<NotificationDocument> = [];
-    if (apiClient) {
-      notifications = await this.notificationsService.getAllActive();
-    }
+    const notifications = await this.getAllActiveNotifications(client);
 
     return from(notifications).pipe(
       map((event) => ({ event: 'notification', data: event })),
     );
+  }
+
+  @SubscribeMessage('notifications/get-all-batch')
+  async getAllActiveEventsBatch(
+    @ConnectedSocket() client: Socket,
+  ): Promise<Array<NotificationDocument>> {
+    return this.getAllActiveNotifications(client);
   }
 
   @SubscribeMessage('notifications/add-received')
@@ -137,5 +139,17 @@ export class WsGateway implements OnModuleInit {
     }
 
     return false;
+  }
+
+  private async getAllActiveNotifications(
+    client: Socket,
+  ): Promise<Array<NotificationDocument>> {
+    const apiClient = socketToApiClient[client.id];
+
+    if (apiClient) {
+      return this.notificationsService.getAllActive();
+    }
+
+    return [];
   }
 }


### PR DESCRIPTION
Clients streamed events and hoped they landed. No confirmation. Nobody was sure. New notifications/get-all-batch hands back every active notification as one ACK payload. The old stream stays. Shared source, zero duplication.

Confirmed delivery. STRONG!