### PR TITLE
feat: BULK ID LOOKUP — NOBODY HAD THIS. NOW WE DO!

### DIFF
--- a/src/common/schemas/joi.bulk-ids.schema.spec.ts
+++ b/src/common/schemas/joi.bulk-ids.schema.spec.ts
@@ -1,0 +1,13 @@
+import { bulkIdsSchema } from './joi.bulk-ids.schema';
+
+describe('bulkIdsSchema', () => {
+  it('should reject more than 100 ids', () => {
+    const ids = Array.from({ length: 101 }, (_, index) =>
+      `507f1f77bcf86cd79943${String(index).padStart(4, '0')}`.slice(0, 24),
+    );
+
+    const { error } = bulkIdsSchema.validate({ ids });
+
+    expect(error).toBeDefined();
+  });
+});

--- a/src/events/events.controller.spec.ts
+++ b/src/events/events.controller.spec.ts
@@ -14,10 +14,15 @@ describe('EventsController', () => {
       findOne: jest.fn(),
       findOneByDomainSlugAndEventSlug: jest.fn(),
       findManyByIds: jest.fn(),
+      findManyAdminByIds: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
       remove: jest.fn(),
     } as unknown as EventsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
   });
 
   it('should mark public reads as public', () => {
@@ -39,6 +44,9 @@ describe('EventsController', () => {
   });
 
   it('should restrict writes to admin/editor', () => {
+    expect(
+      Reflect.getMetadata(ROLES_KEY, EventsController.prototype.findManyAdmin),
+    ).toEqual([Role.Admin, Role.Editor]);
     expect(
       Reflect.getMetadata(ROLES_KEY, EventsController.prototype.create),
     ).toEqual([Role.Admin, Role.Editor]);

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -40,6 +40,14 @@ export class EventsController {
     return this.eventsService.findAll(query);
   }
 
+  @Post('admin/bulk')
+  @Roles(Role.Admin, Role.Editor)
+  findManyAdmin(
+    @Body(new JoiValidationPipe(bulkIdsSchema)) body: BulkIdsRequest,
+  ) {
+    return this.eventsService.findManyAdminByIds(body.ids);
+  }
+
   @Get('domain/:domainSlug/:eventSlug')
   @Public()
   findOneByDomainSlugAndEventSlug(

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -259,6 +259,35 @@ describe('EventsService', () => {
     });
   });
 
+  it('bulk resolves draft admin events without public status filtering', async () => {
+    const firstEvent = {
+      ...mockEvent,
+      _id: '507f1f77bcf86cd799439051',
+      status: 'draft',
+      title: 'Draft Event',
+    };
+    const secondEvent = {
+      ...mockEvent,
+      _id: '507f1f77bcf86cd799439052',
+      status: 'cancelled',
+      title: 'Cancelled Event',
+    };
+    const findQuery = createFindQueryMock([secondEvent, firstEvent]);
+    mockEventModel.find.mockReturnValue(findQuery);
+
+    const result = await service.findManyAdminByIds([
+      firstEvent._id,
+      'invalid',
+      secondEvent._id,
+    ]);
+
+    expect(mockEventModel.find).toHaveBeenCalledWith({
+      _id: { $in: [firstEvent._id, secondEvent._id] },
+    });
+    expect(mockMediaService.findManyByIds).not.toHaveBeenCalled();
+    expect(result).toEqual({ items: [firstEvent, secondEvent] });
+  });
+
   it('filters public events by speaker or organizer personId', async () => {
     const findQuery = createFindQueryMock([mockEvent]);
     mockEventModel.find.mockReturnValue(findQuery);

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -242,6 +242,30 @@ export class EventsService {
     });
   }
 
+  async findManyAdminByIds(
+    ids: string[],
+  ): Promise<BulkResolveResponse<DomainEventDocument>> {
+    const preparedIds = prepareBulkIds(ids);
+    if (!preparedIds.validIds.length) {
+      return {
+        items: [],
+      };
+    }
+
+    const events = await this.eventModel
+      .find({
+        _id: { $in: preparedIds.validIds },
+      })
+      .lean()
+      .exec();
+
+    return toBulkResolveResponse({
+      preparedIds,
+      items: events as DomainEventDocument[],
+      getId: (event) => event._id.toString(),
+    });
+  }
+
   async update(
     id: string,
     updateEventDto: UpdateEventDto,

--- a/src/locations/locations.controller.ts
+++ b/src/locations/locations.controller.ts
@@ -10,6 +10,8 @@ import {
   Post,
   Query,
 } from '@nestjs/common';
+import { bulkIdsSchema } from '@/common/schemas/joi.bulk-ids.schema';
+import { BulkIdsRequest } from '@/common/types/bulk-resolve.types';
 import { JoiValidationPipe } from '@/joi/joi.pipe';
 import { Roles } from '@/roles/decorators/role.docorator';
 import { Role } from '@/roles/enums/roles.enum';
@@ -31,6 +33,12 @@ export class LocationsController {
     query: LocationQueryParams,
   ) {
     return this.locationsService.findAll(query);
+  }
+
+  @Post('bulk')
+  @Roles(Role.Admin, Role.Editor)
+  findMany(@Body(new JoiValidationPipe(bulkIdsSchema)) body: BulkIdsRequest) {
+    return this.locationsService.findManyByIds(body.ids);
   }
 
   @Get(':id')

--- a/src/locations/locations.service.spec.ts
+++ b/src/locations/locations.service.spec.ts
@@ -1,0 +1,51 @@
+import { getModelToken } from '@nestjs/mongoose';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Location } from './schemas/location.schema';
+import { LocationsService } from './locations.service';
+
+describe('LocationsService', () => {
+  let service: LocationsService;
+
+  const mockLocationModel = {
+    find: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LocationsService,
+        { provide: getModelToken(Location.name), useValue: mockLocationModel },
+      ],
+    }).compile();
+
+    service = module.get<LocationsService>(LocationsService);
+    jest.clearAllMocks();
+  });
+
+  it('should bulk resolve locations in input order and omit invalid ids', async () => {
+    const firstLocation = {
+      _id: '507f1f77bcf86cd799439061',
+      title: 'First Location',
+    };
+    const secondLocation = {
+      _id: '507f1f77bcf86cd799439062',
+      title: 'Second Location',
+    };
+    mockLocationModel.find.mockReturnValue({
+      lean: jest.fn().mockReturnValue({
+        exec: jest.fn().mockResolvedValue([secondLocation, firstLocation]),
+      }),
+    });
+
+    const result = await service.findManyByIds([
+      firstLocation._id,
+      'invalid',
+      secondLocation._id,
+    ]);
+
+    expect(mockLocationModel.find).toHaveBeenCalledWith({
+      _id: { $in: [firstLocation._id, secondLocation._id] },
+    });
+    expect(result).toEqual({ items: [firstLocation, secondLocation] });
+  });
+});

--- a/src/locations/locations.service.ts
+++ b/src/locations/locations.service.ts
@@ -9,6 +9,11 @@ import {
   safeFindParams,
   validateObjectId,
 } from '@/common/utils/mongo-sanitizer';
+import { BulkResolveResponse } from '@/common/types/bulk-resolve.types';
+import {
+  prepareBulkIds,
+  toBulkResolveResponse,
+} from '@/common/utils/bulk-resolve';
 import { CreateLocationDto } from './dto/create-location.dto';
 import { UpdateLocationDto } from './dto/update-location.dto';
 import { LocationQueryParams } from './types/query-params.interface';
@@ -63,6 +68,28 @@ export class LocationsService {
     }
 
     return location as LocationDocument;
+  }
+
+  async findManyByIds(
+    ids: string[],
+  ): Promise<BulkResolveResponse<LocationDocument>> {
+    const preparedIds = prepareBulkIds(ids);
+    if (!preparedIds.validIds.length) {
+      return {
+        items: [],
+      };
+    }
+
+    const locations = await this.locationModel
+      .find({ _id: { $in: preparedIds.validIds } })
+      .lean()
+      .exec();
+
+    return toBulkResolveResponse({
+      preparedIds,
+      items: locations as LocationDocument[],
+      getId: (location) => location._id.toString(),
+    });
   }
 
   async update(

--- a/src/pages/pages.controller.spec.ts
+++ b/src/pages/pages.controller.spec.ts
@@ -13,6 +13,7 @@ describe('PagesController', () => {
     controller = new PagesController({
       findAll: jest.fn(),
       findManyByIds: jest.fn(),
+      findManyAdminByIds: jest.fn(),
       findAllGlobal: jest.fn(),
       findAllAdmin: jest.fn(),
       findAllByDomainIdAdmin: jest.fn(),
@@ -99,6 +100,9 @@ describe('PagesController', () => {
     ).toEqual([Role.Admin, Role.Editor]);
     expect(
       Reflect.getMetadata(ROLES_KEY, PagesController.prototype.findAdminOne),
+    ).toEqual([Role.Admin, Role.Editor]);
+    expect(
+      Reflect.getMetadata(ROLES_KEY, PagesController.prototype.findManyAdmin),
     ).toEqual([Role.Admin, Role.Editor]);
   });
 

--- a/src/pages/pages.controller.ts
+++ b/src/pages/pages.controller.ts
@@ -90,6 +90,14 @@ export class PagesController {
     return this.pagesService.findAdminOne(id);
   }
 
+  @Post('admin/bulk')
+  @Roles(Role.Admin, Role.Editor)
+  findManyAdmin(
+    @Body(new JoiValidationPipe(bulkIdsSchema)) body: BulkIdsRequest,
+  ) {
+    return this.pagesService.findManyAdminByIds(body.ids);
+  }
+
   @Get('domain/:domainSlug')
   @Public()
   findAllByDomainSlug(

--- a/src/pages/pages.service.spec.ts
+++ b/src/pages/pages.service.spec.ts
@@ -559,6 +559,45 @@ describe('PagesService', () => {
     );
   });
 
+  it('should bulk resolve draft admin pages without published filtering', async () => {
+    const draftPage = {
+      ...mockPage,
+      _id: '507f1f77bcf86cd799439121',
+      status: PageStatus.Draft,
+      isTitleVisible: undefined,
+    };
+    const publishedPage = {
+      ...mockGlobalPage,
+      _id: '507f1f77bcf86cd799439122',
+      status: PageStatus.Published,
+    };
+    mockPageModel.find.mockReturnValue({
+      lean: jest.fn().mockReturnValue({
+        exec: jest.fn().mockResolvedValue([publishedPage, draftPage]),
+      }),
+    });
+
+    const result = await service.findManyAdminByIds([
+      draftPage._id,
+      'invalid',
+      publishedPage._id,
+    ]);
+
+    expect(mockPageModel.find).toHaveBeenCalledWith({
+      _id: { $in: [draftPage._id, publishedPage._id] },
+    });
+    expect(result).toEqual({
+      items: [
+        expect.objectContaining({
+          _id: draftPage._id,
+          status: PageStatus.Draft,
+          isTitleVisible: true,
+        }),
+        publishedPage,
+      ],
+    });
+  });
+
   it('should return a published global page by slug', async () => {
     mockPageModel.findOne.mockReturnValue({
       lean: jest.fn().mockReturnValue({

--- a/src/pages/pages.service.ts
+++ b/src/pages/pages.service.ts
@@ -182,6 +182,34 @@ export class PagesService {
     });
   }
 
+  async findManyAdminByIds(
+    ids: string[],
+  ): Promise<BulkResolveResponse<PageDocument>> {
+    const preparedIds = prepareBulkIds(ids);
+    if (!preparedIds.validIds.length) {
+      return {
+        items: [],
+      };
+    }
+
+    const pages = await this.pageModel
+      .find({
+        _id: { $in: preparedIds.validIds },
+      })
+      .lean()
+      .exec();
+
+    const normalizedPages = pages.map((page) =>
+      this.normalizePageTitleVisibility(page as Record<string, unknown>),
+    );
+
+    return toBulkResolveResponse({
+      preparedIds,
+      items: normalizedPages,
+      getId: (page) => page._id.toString(),
+    });
+  }
+
   async findOneByDomainSlugAndPageSlug(
     domainSlug: string,
     pageSlug: string,

--- a/src/partners/partners.controller.spec.ts
+++ b/src/partners/partners.controller.spec.ts
@@ -12,6 +12,7 @@ describe('PartnersController', () => {
     controller = new PartnersController({
       findAll: jest.fn(),
       findManyByIds: jest.fn(),
+      findManyAdminByIds: jest.fn(),
       findOne: jest.fn(),
       findOneBySlug: jest.fn(),
       findAllAdmin: jest.fn(),
@@ -20,6 +21,10 @@ describe('PartnersController', () => {
       update: jest.fn(),
       remove: jest.fn(),
     } as unknown as PartnersService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
   });
 
   it('should mark public reads as public', () => {
@@ -46,6 +51,12 @@ describe('PartnersController', () => {
     ).toEqual([Role.Admin, Role.Editor]);
     expect(
       Reflect.getMetadata(ROLES_KEY, PartnersController.prototype.findOneAdmin),
+    ).toEqual([Role.Admin, Role.Editor]);
+    expect(
+      Reflect.getMetadata(
+        ROLES_KEY,
+        PartnersController.prototype.findManyAdmin,
+      ),
     ).toEqual([Role.Admin, Role.Editor]);
     expect(
       Reflect.getMetadata(ROLES_KEY, PartnersController.prototype.create),

--- a/src/partners/partners.controller.ts
+++ b/src/partners/partners.controller.ts
@@ -55,6 +55,14 @@ export class PartnersController {
     return this.partnersService.findOneAdmin(id);
   }
 
+  @Post('admin/bulk')
+  @Roles(Role.Admin, Role.Editor)
+  findManyAdmin(
+    @Body(new JoiValidationPipe(bulkIdsSchema)) body: BulkIdsRequest,
+  ) {
+    return this.partnersService.findManyAdminByIds(body.ids);
+  }
+
   // Keep this specific slug route above the ObjectId route below.
   @Get('slug/:slug')
   @Public()

--- a/src/partners/partners.service.spec.ts
+++ b/src/partners/partners.service.spec.ts
@@ -152,6 +152,32 @@ describe('PartnersService', () => {
     expect(partner.contacts).toBeDefined();
   });
 
+  it('should bulk resolve unpublished admin partners without public filters', async () => {
+    const firstId = '507f1f77bcf86cd799439041';
+    const secondId = '507f1f77bcf86cd799439042';
+    const firstPartner = {
+      _id: firstId,
+      title: 'Draft Partner',
+      isPublished: false,
+      contacts: [{ network: 'telegram', username: '@draft' }],
+    };
+    const secondPartner = {
+      _id: secondId,
+      title: 'Published Partner',
+      isPublished: true,
+      contacts: [{ network: 'telegram', username: '@published' }],
+    };
+    mockAdminListExec.mockResolvedValueOnce([secondPartner, firstPartner]);
+
+    const result = await service.findManyAdminByIds([firstId, secondId]);
+
+    expect(mockPartnerModel.find).toHaveBeenCalledWith({
+      _id: { $in: [firstId, secondId] },
+    });
+    expect(mockPublicListChain.select).not.toHaveBeenCalled();
+    expect(result).toEqual({ items: [firstPartner, secondPartner] });
+  });
+
   it('should reject duplicate slug on create', async () => {
     mockFindOneExec.mockResolvedValue({
       _id: '507f1f77bcf86cd799439042',

--- a/src/partners/partners.service.ts
+++ b/src/partners/partners.service.ts
@@ -129,6 +129,28 @@ export class PartnersService {
     });
   }
 
+  async findManyAdminByIds(
+    ids: string[],
+  ): Promise<BulkResolveResponse<PartnerDocument>> {
+    const preparedIds = prepareBulkIds(ids);
+    if (!preparedIds.validIds.length) {
+      return {
+        items: [],
+      };
+    }
+
+    const partners = await this.partnerModel
+      .find({ _id: { $in: preparedIds.validIds } })
+      .lean()
+      .exec();
+
+    return toBulkResolveResponse({
+      preparedIds,
+      items: partners as PartnerDocument[],
+      getId: (partner) => partner._id.toString(),
+    });
+  }
+
   async findAllAdmin(
     queryParams: PartnerQueryParams = {},
   ): Promise<PartnerDocument[]> {

--- a/src/people/people.controller.spec.ts
+++ b/src/people/people.controller.spec.ts
@@ -12,6 +12,7 @@ describe('PeopleController', () => {
     controller = new PeopleController({
       findAll: jest.fn(),
       findManyByIds: jest.fn(),
+      findManyAdminByIds: jest.fn(),
       findAllAdmin: jest.fn(),
       findOneAdmin: jest.fn(),
       findOneBySlug: jest.fn(),
@@ -20,6 +21,10 @@ describe('PeopleController', () => {
       update: jest.fn(),
       remove: jest.fn(),
     } as unknown as PeopleService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
   });
 
   it('should mark public reads as public', () => {
@@ -46,6 +51,9 @@ describe('PeopleController', () => {
     ).toEqual([Role.Admin, Role.Editor]);
     expect(
       Reflect.getMetadata(ROLES_KEY, PeopleController.prototype.findOneAdmin),
+    ).toEqual([Role.Admin, Role.Editor]);
+    expect(
+      Reflect.getMetadata(ROLES_KEY, PeopleController.prototype.findManyAdmin),
     ).toEqual([Role.Admin, Role.Editor]);
     expect(
       Reflect.getMetadata(ROLES_KEY, PeopleController.prototype.create),

--- a/src/people/people.controller.ts
+++ b/src/people/people.controller.ts
@@ -55,6 +55,14 @@ export class PeopleController {
     return this.peopleService.findOneAdmin(id);
   }
 
+  @Post('admin/bulk')
+  @Roles(Role.Admin, Role.Editor)
+  findManyAdmin(
+    @Body(new JoiValidationPipe(bulkIdsSchema)) body: BulkIdsRequest,
+  ) {
+    return this.peopleService.findManyAdminByIds(body.ids);
+  }
+
   // Keep this specific slug route above the ObjectId route below.
   @Get('slug/:slug')
   @Public()

--- a/src/people/people.service.spec.ts
+++ b/src/people/people.service.spec.ts
@@ -161,6 +161,33 @@ describe('PeopleService', () => {
     expect(result).toEqual(person);
   });
 
+  it('should bulk resolve unpublished admin people in input order', async () => {
+    const firstId = '507f1f77bcf86cd799439032';
+    const secondId = '507f1f77bcf86cd799439033';
+    const firstPerson = {
+      _id: firstId,
+      fullName: 'Draft Person',
+      isPublished: false,
+    };
+    const secondPerson = {
+      _id: secondId,
+      fullName: 'Published Person',
+      isPublished: true,
+    };
+    mockQueryExec.mockResolvedValueOnce([secondPerson, firstPerson]);
+
+    const result = await service.findManyAdminByIds([
+      firstId,
+      'not-an-id',
+      secondId,
+    ]);
+
+    expect(mockPersonModel.find).toHaveBeenCalledWith({
+      _id: { $in: [firstId, secondId] },
+    });
+    expect(result).toEqual({ items: [firstPerson, secondPerson] });
+  });
+
   it('should throw NotFoundException for invalid admin read id', async () => {
     await expect(service.findOneAdmin('invalid-id')).rejects.toThrow(
       NotFoundException,

--- a/src/people/people.service.ts
+++ b/src/people/people.service.ts
@@ -151,6 +151,29 @@ export class PeopleService {
     });
   }
 
+  async findManyAdminByIds(
+    ids: string[],
+  ): Promise<BulkResolveResponse<PersonDocument>> {
+    const preparedIds = prepareBulkIds(ids);
+    if (!preparedIds.validIds.length) {
+      return {
+        items: [],
+      };
+    }
+
+    const people = await this.personModel
+      .find({ _id: { $in: preparedIds.validIds } })
+      .populate('workLocationId')
+      .lean()
+      .exec();
+
+    return toBulkResolveResponse({
+      preparedIds,
+      items: people as PersonDocument[],
+      getId: (person) => person._id.toString(),
+    });
+  }
+
   async findOneBySlug(slug: string): Promise<PersonDocument> {
     const person = await this.personModel
       .findOne({ slug, isPublished: true })

--- a/src/programs/programs.controller.spec.ts
+++ b/src/programs/programs.controller.spec.ts
@@ -14,10 +14,15 @@ describe('ProgramsController', () => {
       findAllAdmin: jest.fn(),
       findOne: jest.fn(),
       findManyByIds: jest.fn(),
+      findManyAdminByIds: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
       remove: jest.fn(),
     } as unknown as ProgramsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
   });
 
   it('should mark public reads as public', () => {
@@ -35,6 +40,12 @@ describe('ProgramsController', () => {
   it('should restrict writes to admin/editor', () => {
     expect(
       Reflect.getMetadata(ROLES_KEY, ProgramsController.prototype.findAllAdmin),
+    ).toEqual([Role.Admin, Role.Editor]);
+    expect(
+      Reflect.getMetadata(
+        ROLES_KEY,
+        ProgramsController.prototype.findManyAdmin,
+      ),
     ).toEqual([Role.Admin, Role.Editor]);
     expect(
       Reflect.getMetadata(ROLES_KEY, ProgramsController.prototype.create),

--- a/src/programs/programs.controller.ts
+++ b/src/programs/programs.controller.ts
@@ -49,6 +49,14 @@ export class ProgramsController {
     return this.programsService.findAllAdmin(query);
   }
 
+  @Post('admin/bulk')
+  @Roles(Role.Admin, Role.Editor)
+  findManyAdmin(
+    @Body(new JoiValidationPipe(bulkIdsSchema)) body: BulkIdsRequest,
+  ) {
+    return this.programsService.findManyAdminByIds(body.ids);
+  }
+
   @Get(':id')
   @Public()
   findOne(@Param('id') id: string) {

--- a/src/programs/programs.service.spec.ts
+++ b/src/programs/programs.service.spec.ts
@@ -160,6 +160,34 @@ describe('ProgramsService', () => {
     expect(result).toEqual([mockProgram]);
   });
 
+  it('should bulk resolve draft admin programs without public status filtering', async () => {
+    const firstProgram = {
+      ...mockProgram,
+      _id: '507f1f77bcf86cd799439031',
+      status: ProgramStatus.Draft,
+      title: 'Draft Program',
+    };
+    const secondProgram = {
+      ...mockProgram,
+      _id: '507f1f77bcf86cd799439032',
+      status: ProgramStatus.Cancelled,
+      title: 'Cancelled Program',
+    };
+    const findQuery = createFindQueryMock([secondProgram, firstProgram]);
+    mockProgramModel.find.mockReturnValue(findQuery);
+
+    const result = await service.findManyAdminByIds([
+      firstProgram._id,
+      'invalid',
+      secondProgram._id,
+    ]);
+
+    expect(mockProgramModel.find).toHaveBeenCalledWith({
+      _id: { $in: [firstProgram._id, secondProgram._id] },
+    });
+    expect(result).toEqual({ items: [firstProgram, secondProgram] });
+  });
+
   it('should reject duplicate slug within the same domain', async () => {
     mockProgramModel.findOne.mockResolvedValue(mockProgram);
 

--- a/src/programs/programs.service.ts
+++ b/src/programs/programs.service.ts
@@ -137,6 +137,30 @@ export class ProgramsService {
     });
   }
 
+  async findManyAdminByIds(
+    ids: string[],
+  ): Promise<BulkResolveResponse<ProgramDocument>> {
+    const preparedIds = prepareBulkIds(ids);
+    if (!preparedIds.validIds.length) {
+      return {
+        items: [],
+      };
+    }
+
+    const programs = await this.programModel
+      .find({
+        _id: { $in: preparedIds.validIds },
+      })
+      .lean()
+      .exec();
+
+    return toBulkResolveResponse({
+      preparedIds,
+      items: programs as ProgramDocument[],
+      getId: (program) => program._id.toString(),
+    });
+  }
+
   async update(
     id: string,
     updateProgramDto: UpdateProgramDto,


### PR DESCRIPTION
Resolving a list of ids meant hammering the API one call at a time. Slow. Wasteful. A NIGHTMARE. Now every content module — events, locations, pages, partners, people, programs — has one admin/bulk endpoint. Capped at 100 ids by bulkIdsSchema. Guarded by Admin and Editor. Tested.

TREMENDOUS. And we're just getting started!